### PR TITLE
[fish-sonic][sensors] Add acoustic module driver and data logging

### DIFF
--- a/aerial_robot_nerve/spinal/launch/bridge.launch
+++ b/aerial_robot_nerve/spinal/launch/bridge.launch
@@ -1,8 +1,8 @@
 <launch>
   <arg name="mode" default="serial" />
-  <arg name="dev" default="vim4" />
+  <arg name="dev" default="pc" />
 
-  <arg name="serial_port" value="/dev/ttyUSB0" if="$(eval arg('dev') == 'pc')" />
+  <arg name="serial_port" value="/dev/ttyUSB1" if="$(eval arg('dev') == 'pc')" />
   <arg name="serial_port" value="/dev/ttyS4" if="$(eval arg('dev') == 'vim4')" />
   <arg name="serial_baud" default="921600" />
 

--- a/robots/robotic_fish/CMakeLists.txt
+++ b/robots/robotic_fish/CMakeLists.txt
@@ -17,6 +17,7 @@ catkin_install_python(PROGRAMS
         scripts/spring_teleop.py
         scripts/loop_send_servo_cmd.py
         scripts/servo_keyboard_cmd.py
+        scripts/sonic_teleop.py
         scripts/teleop.py
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
@@ -24,6 +25,10 @@ catkin_install_python(PROGRAMS
 install(PROGRAMS
         scripts/loop_send_servo_cmd.bash
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
 include_directories(

--- a/robots/robotic_fish/README.md
+++ b/robots/robotic_fish/README.md
@@ -188,6 +188,36 @@ roslaunch robotic_fish spring_teleop.launch dev:=pc
 roslaunch robotic_fish advance_teleop.launch dev:=pc
 ```
 
+使用 sonic 总体程序并同时启动 ADC/DAC：
+
+```bash
+roslaunch robotic_fish sonic_teleop.launch \
+  dev:=vim4 \
+  enable_sensor_io:=true
+```
+
+`sonic_teleop.launch` 默认同时启动 rosbag，文件保存在用户主目录，名称类似 `~/sonic_2026-09-01-18-30-00.bag`。录制内容包括：
+
+- ADC 三通道批数据（原始电压、校准电压、校准标识和时间戳）
+- DAC 命令与状态、节点诊断
+- 手柄输入、IMU、舵机目标命令与状态反馈
+
+改变保存目录或文件名前缀时，目标目录需要预先创建：
+
+```bash
+mkdir -p ~/bags
+roslaunch robotic_fish sonic_teleop.launch \
+  dev:=vim4 \
+  enable_sensor_io:=true \
+  bag_prefix:=$HOME/bags/sonic_
+```
+
+如本次运行不需要录制，可使用 `record_bag:=false`。停止整个 launch 时，rosbag 会同步结束并正常关闭文件。录制后可检查内容：
+
+```bash
+rosbag info ~/sonic_*.bag
+```
+
 ## 6. 手柄控制
 
 控制逻辑使用 `sensor_msgs/Joy` 的数组索引，而不是统一的按键名称。下表描述代码中的默认索引；实际物理按键请通过 `rostopic echo /joy` 确认。

--- a/robots/robotic_fish/launch/record.launch
+++ b/robots/robotic_fish/launch/record.launch
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="enabled" default="true"/>
+  <arg name="bag_prefix" default="$(env HOME)/sonic_"/>
+
+  <node if="$(arg enabled)"
+        pkg="rosbag"
+        type="record"
+        name="sonic_bag_recorder"
+        output="screen"
+        args="-o $(arg bag_prefix)
+              /robotic_fish/adc/samples
+              /robotic_fish/dac/command
+              /robotic_fish/dac/state
+              /diagnostics
+              /joy
+              /imu
+              /servo/target_states
+              /servo/states"/>
+</launch>

--- a/robots/robotic_fish/launch/sonic_teleop.launch
+++ b/robots/robotic_fish/launch/sonic_teleop.launch
@@ -2,6 +2,13 @@
 <launch>
 
   <arg name="dev" default="vim4" doc="choose between [pc, vim4]"/>
+  <arg name="enable_sensor_io" default="false"/>
+  <arg name="enable_adc" default="true"/>
+  <arg name="enable_dac" default="true"/>
+  <arg name="enable_agc" default="false"/>
+  <arg name="sensor_io_config" default="$(find robotic_fish_io)/config/io.yaml"/>
+  <arg name="record_bag" default="true"/>
+  <arg name="bag_prefix" default="$(env HOME)/sonic_"/>
 
   <include file="$(find spinal)/launch/bridge.launch" if = "$(eval arg('dev') == 'pc')" >
     <arg name="dev" value="$(arg dev)" />
@@ -21,4 +28,17 @@
     <param name="dev" value="/dev/input/js0"/>
     <param name="coalesce_interval" value="0.025"/>
   </node>
+
+  <include if="$(arg enable_sensor_io)"
+           file="$(find robotic_fish_io)/launch/sensor_io.launch">
+    <arg name="config" value="$(arg sensor_io_config)"/>
+    <arg name="enable_adc" value="$(arg enable_adc)"/>
+    <arg name="enable_dac" value="$(arg enable_dac)"/>
+    <arg name="enable_agc" value="$(arg enable_agc)"/>
+  </include>
+
+  <include file="$(find robotic_fish)/launch/record.launch">
+    <arg name="enabled" value="$(arg record_bag)"/>
+    <arg name="bag_prefix" value="$(arg bag_prefix)"/>
+  </include>
 </launch>

--- a/robots/robotic_fish/package.xml
+++ b/robots/robotic_fish/package.xml
@@ -63,6 +63,7 @@
   <exec_depend>spinal</exec_depend>
   <exec_depend>joy</exec_depend>
   <exec_depend>robotic_fish_io</exec_depend>
+  <exec_depend>rosbag</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/robots/robotic_fish_io/README.md
+++ b/robots/robotic_fish_io/README.md
@@ -15,7 +15,7 @@ Each sample contains both `voltage` (the direct ADS1115 conversion) and
 `calibrated_voltage`. Calibration is loaded from the JSON file selected under
 `adc.calibration.file` in `config/io.yaml`. The packaged default is the validated
 three-channel independent transfer table
-`adc_independent_transfer_20260818_183014_calbri01_raw.json`.
+`adc_independent_transfer_20260901_171408_calbri05_raw.json`.
 
 ADC0, ADC1, and ADC2 each use their own raw ADC voltage to query a piecewise
 linear curve. Calibration has no runtime dependency on the DAC voltage. If any
@@ -31,7 +31,7 @@ adc:
   calibration:
     enabled: true
     required: true
-    file: calibration/adc_independent_transfer_20260818_183014_calbri01_raw.json
+    file: calibration/adc_independent_transfer_20260901_171408_calbri05_raw.json
 ```
 
 An absolute path is also accepted. With `required: true`, a missing, malformed,

--- a/robots/robotic_fish_io/config/calibration/adc_independent_transfer_20260901_171408_calbri05_raw.json
+++ b/robots/robotic_fish_io/config/calibration/adc_independent_transfer_20260901_171408_calbri05_raw.json
@@ -1,0 +1,1963 @@
+{
+  "schema_version": 1,
+  "calibration_id": "adc_independent_transfer_20260901_171408_calbri05_raw",
+  "calibration_type": "per_channel_piecewise_linear",
+  "created_at": "2026-09-01T17:35:07+08:00",
+  "channel_order": [
+    "ADC0",
+    "ADC1",
+    "ADC2"
+  ],
+  "source": {
+    "file": "adc_record_20260901_171408_calbri05_raw.csv",
+    "sha256": "67e360b8da62ef6d60fef986b0bb046bf5d55e76c4e94271428ed069aefef14f",
+    "data_rows": 60500,
+    "fields_used": [
+      "timestamp",
+      "sample_id",
+      "adc0_voltage_v",
+      "adc1_voltage_v",
+      "adc2_voltage_v"
+    ],
+    "profile": {
+      "data_rows": 60500,
+      "duration_s": 1210.0519998073578,
+      "first_sample_id": 1,
+      "last_sample_id": 60500,
+      "median_interval_ms": 19.999980926513672,
+      "adc_ranges_v": [
+        {
+          "min": 0.011625,
+          "max": 3.670625
+        },
+        {
+          "min": 0.012125,
+          "max": 3.622125
+        },
+        {
+          "min": 0.01325,
+          "max": 3.644375
+        }
+      ],
+      "calibration_applied_rows": 0,
+      "filter_applied_rows": 0
+    }
+  },
+  "conditions": {
+    "reference_type": "three_channel_adc_consensus",
+    "common_input_required": true,
+    "absolute_voltage_reference": false,
+    "power_source": "lithium_battery",
+    "input_source": "signal_generator",
+    "notes": "命令行采集；DAC 0-1.2V、步长0.01V；每档10秒；50组三通道/秒；无网页轮询、页面校准和滤波"
+  },
+  "processing": {
+    "reference": "median_of_three_channel_medians",
+    "segmentation": "adc_common_observation_change_detection",
+    "settling_time_ms": 1000,
+    "end_guard_time_ms": 1000,
+    "validation_split": "first_half_fit_second_half_holdout",
+    "validation_observation_window_ms": 500,
+    "deployed_fit": "all_stable_samples_after_validation",
+    "interpolation": "piecewise_linear_per_channel",
+    "runtime_dac_dependency": false,
+    "generation_dac_dependency": false,
+    "offset_correction": false
+  },
+  "detection": {
+    "detected_platforms": 121,
+    "block_seconds": 0.2,
+    "minimum_change_v": 0.00025,
+    "mad_multiplier": 3.0,
+    "relative_change_floor": 0.003,
+    "persistence_blocks": 4
+  },
+  "validity": {
+    "endpoint_tolerance_v": 0.0025,
+    "recommended_max_voltage_v": 3.563375,
+    "out_of_range": "reject_group_and_fallback_raw"
+  },
+  "curves": [
+    {
+      "channel": "ADC0",
+      "input_min_v": 0.01175,
+      "input_max_v": 3.663,
+      "nodes": [
+        {
+          "raw_voltage_v": 0.01175,
+          "reference_voltage_v": 0.01225,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.0125,
+          "reference_voltage_v": 0.013,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.01325,
+          "reference_voltage_v": 0.01375,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.014,
+          "reference_voltage_v": 0.0145,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.014875,
+          "reference_voltage_v": 0.015375,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.01575,
+          "reference_voltage_v": 0.01625,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.01675,
+          "reference_voltage_v": 0.017125,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.01775,
+          "reference_voltage_v": 0.018125,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.018875,
+          "reference_voltage_v": 0.019125,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 0.02,
+          "reference_voltage_v": 0.02025,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.021125,
+          "reference_voltage_v": 0.021375,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.022375,
+          "reference_voltage_v": 0.022625,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.023875,
+          "reference_voltage_v": 0.024125,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.0255,
+          "reference_voltage_v": 0.025625,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.027,
+          "reference_voltage_v": 0.027125,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.028625,
+          "reference_voltage_v": 0.028625,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.030375,
+          "reference_voltage_v": 0.030375,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.031875,
+          "reference_voltage_v": 0.031875,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.03325,
+          "reference_voltage_v": 0.03325,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 0.035,
+          "reference_voltage_v": 0.035,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.036875,
+          "reference_voltage_v": 0.036875,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.04,
+          "reference_voltage_v": 0.04,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.042125,
+          "reference_voltage_v": 0.042125,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.044375,
+          "reference_voltage_v": 0.044375,
+          "steady_sample_count": 393
+        },
+        {
+          "raw_voltage_v": 0.046625,
+          "reference_voltage_v": 0.046625,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.049125,
+          "reference_voltage_v": 0.049125,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.05175,
+          "reference_voltage_v": 0.05175,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.0545,
+          "reference_voltage_v": 0.0545,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.05725,
+          "reference_voltage_v": 0.05725,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.06025,
+          "reference_voltage_v": 0.06025,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.063375,
+          "reference_voltage_v": 0.063375,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.066625,
+          "reference_voltage_v": 0.066625,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.07,
+          "reference_voltage_v": 0.07,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.07375,
+          "reference_voltage_v": 0.07375,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.0775,
+          "reference_voltage_v": 0.0775,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.0815,
+          "reference_voltage_v": 0.0815,
+          "steady_sample_count": 400
+        },
+        {
+          "raw_voltage_v": 0.085375,
+          "reference_voltage_v": 0.085375,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.089625,
+          "reference_voltage_v": 0.089625,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.094125,
+          "reference_voltage_v": 0.094125,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.09875,
+          "reference_voltage_v": 0.09875,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.10375,
+          "reference_voltage_v": 0.10375,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.108875,
+          "reference_voltage_v": 0.108875,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.117,
+          "reference_voltage_v": 0.117,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.12275,
+          "reference_voltage_v": 0.12275,
+          "steady_sample_count": 410
+        },
+        {
+          "raw_voltage_v": 0.12875,
+          "reference_voltage_v": 0.12875,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.135,
+          "reference_voltage_v": 0.135,
+          "steady_sample_count": 402
+        },
+        {
+          "raw_voltage_v": 0.14175,
+          "reference_voltage_v": 0.14175,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 0.148625,
+          "reference_voltage_v": 0.148625,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.156,
+          "reference_voltage_v": 0.156,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.163625,
+          "reference_voltage_v": 0.163625,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.1715,
+          "reference_voltage_v": 0.1715,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.179875,
+          "reference_voltage_v": 0.179875,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.1885,
+          "reference_voltage_v": 0.1885,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.1975,
+          "reference_voltage_v": 0.1975,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.207,
+          "reference_voltage_v": 0.206875,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.217,
+          "reference_voltage_v": 0.216625,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 0.227375,
+          "reference_voltage_v": 0.227,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.23875,
+          "reference_voltage_v": 0.238125,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 0.2505,
+          "reference_voltage_v": 0.24975,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.262375,
+          "reference_voltage_v": 0.2615,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 0.274875,
+          "reference_voltage_v": 0.27375,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.28725,
+          "reference_voltage_v": 0.286,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.301,
+          "reference_voltage_v": 0.2995,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.32275,
+          "reference_voltage_v": 0.321,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.33825,
+          "reference_voltage_v": 0.33625,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.35425,
+          "reference_voltage_v": 0.352,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.370875,
+          "reference_voltage_v": 0.368375,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 0.3885,
+          "reference_voltage_v": 0.38575,
+          "steady_sample_count": 383
+        },
+        {
+          "raw_voltage_v": 0.406875,
+          "reference_voltage_v": 0.403875,
+          "steady_sample_count": 417
+        },
+        {
+          "raw_voltage_v": 0.426125,
+          "reference_voltage_v": 0.42275,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.4465,
+          "reference_voltage_v": 0.44275,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.467375,
+          "reference_voltage_v": 0.46325,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.489375,
+          "reference_voltage_v": 0.484875,
+          "steady_sample_count": 408
+        },
+        {
+          "raw_voltage_v": 0.512375,
+          "reference_voltage_v": 0.5075,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.536625,
+          "reference_voltage_v": 0.53125,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.561875,
+          "reference_voltage_v": 0.556,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 0.58825,
+          "reference_voltage_v": 0.581875,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.61575,
+          "reference_voltage_v": 0.60875,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.645,
+          "reference_voltage_v": 0.637375,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.675375,
+          "reference_voltage_v": 0.66725,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.70725,
+          "reference_voltage_v": 0.698375,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.7405,
+          "reference_voltage_v": 0.730875,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.777375,
+          "reference_voltage_v": 0.767,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.832625,
+          "reference_voltage_v": 0.82075,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.871125,
+          "reference_voltage_v": 0.8585,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.9095,
+          "reference_voltage_v": 0.896125,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.951875,
+          "reference_voltage_v": 0.9375,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.99575,
+          "reference_voltage_v": 0.98025,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 1.041875,
+          "reference_voltage_v": 1.02525,
+          "steady_sample_count": 401
+        },
+        {
+          "raw_voltage_v": 1.09075,
+          "reference_voltage_v": 1.073,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 1.141375,
+          "reference_voltage_v": 1.12225,
+          "steady_sample_count": 408
+        },
+        {
+          "raw_voltage_v": 1.194625,
+          "reference_voltage_v": 1.174125,
+          "steady_sample_count": 393
+        },
+        {
+          "raw_voltage_v": 1.250375,
+          "reference_voltage_v": 1.2285,
+          "steady_sample_count": 387
+        },
+        {
+          "raw_voltage_v": 1.30875,
+          "reference_voltage_v": 1.285375,
+          "steady_sample_count": 415
+        },
+        {
+          "raw_voltage_v": 1.371,
+          "reference_voltage_v": 1.345875,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 1.434875,
+          "reference_voltage_v": 1.408125,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 1.502375,
+          "reference_voltage_v": 1.473875,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 1.57175,
+          "reference_voltage_v": 1.5411875,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 1.64525,
+          "reference_voltage_v": 1.612375,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 1.72225,
+          "reference_voltage_v": 1.68725,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 1.802375,
+          "reference_voltage_v": 1.765,
+          "steady_sample_count": 392
+        },
+        {
+          "raw_voltage_v": 1.886,
+          "reference_voltage_v": 1.8461875,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 1.974,
+          "reference_voltage_v": 1.931375,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 2.064875,
+          "reference_voltage_v": 2.01975,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 2.210125,
+          "reference_voltage_v": 2.1605,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 2.312875,
+          "reference_voltage_v": 2.2600625,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 2.4215,
+          "reference_voltage_v": 2.364875,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 2.534375,
+          "reference_voltage_v": 2.4745,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 2.652625,
+          "reference_voltage_v": 2.588,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 2.775875,
+          "reference_voltage_v": 2.707625,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 2.90525,
+          "reference_voltage_v": 2.833,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 3.02675,
+          "reference_voltage_v": 2.963125,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 3.133625,
+          "reference_voltage_v": 3.08325,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 3.227,
+          "reference_voltage_v": 3.182375,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 3.304875,
+          "reference_voltage_v": 3.264125,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 3.375625,
+          "reference_voltage_v": 3.33775,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 3.43775,
+          "reference_voltage_v": 3.402125,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 3.499875,
+          "reference_voltage_v": 3.466625,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 3.55775,
+          "reference_voltage_v": 3.526625,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 3.612,
+          "reference_voltage_v": 3.58275,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 3.663,
+          "reference_voltage_v": 3.6355,
+          "steady_sample_count": 400
+        }
+      ]
+    },
+    {
+      "channel": "ADC1",
+      "input_min_v": 0.01225,
+      "input_max_v": 3.613375,
+      "nodes": [
+        {
+          "raw_voltage_v": 0.01225,
+          "reference_voltage_v": 0.01225,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.013,
+          "reference_voltage_v": 0.013,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.01375,
+          "reference_voltage_v": 0.01375,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.0145,
+          "reference_voltage_v": 0.0145,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.015375,
+          "reference_voltage_v": 0.015375,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.01625,
+          "reference_voltage_v": 0.01625,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.017125,
+          "reference_voltage_v": 0.017125,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.018125,
+          "reference_voltage_v": 0.018125,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.019125,
+          "reference_voltage_v": 0.019125,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 0.02025,
+          "reference_voltage_v": 0.02025,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.021375,
+          "reference_voltage_v": 0.021375,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.022625,
+          "reference_voltage_v": 0.022625,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.024125,
+          "reference_voltage_v": 0.024125,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.025625,
+          "reference_voltage_v": 0.025625,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.027125,
+          "reference_voltage_v": 0.027125,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.028625,
+          "reference_voltage_v": 0.028625,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.03025,
+          "reference_voltage_v": 0.030375,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.03175,
+          "reference_voltage_v": 0.031875,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.033125,
+          "reference_voltage_v": 0.03325,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 0.03475,
+          "reference_voltage_v": 0.035,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.036625,
+          "reference_voltage_v": 0.036875,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.039625,
+          "reference_voltage_v": 0.04,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.04175,
+          "reference_voltage_v": 0.042125,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.043875,
+          "reference_voltage_v": 0.044375,
+          "steady_sample_count": 393
+        },
+        {
+          "raw_voltage_v": 0.046,
+          "reference_voltage_v": 0.046625,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.0485,
+          "reference_voltage_v": 0.049125,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.051,
+          "reference_voltage_v": 0.05175,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.053625,
+          "reference_voltage_v": 0.0545,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.056375,
+          "reference_voltage_v": 0.05725,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.05925,
+          "reference_voltage_v": 0.06025,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.06225,
+          "reference_voltage_v": 0.063375,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.065375,
+          "reference_voltage_v": 0.066625,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.06875,
+          "reference_voltage_v": 0.07,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.072375,
+          "reference_voltage_v": 0.07375,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.076,
+          "reference_voltage_v": 0.0775,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.07975,
+          "reference_voltage_v": 0.0815,
+          "steady_sample_count": 400
+        },
+        {
+          "raw_voltage_v": 0.0835,
+          "reference_voltage_v": 0.085375,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.087625,
+          "reference_voltage_v": 0.089625,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.092,
+          "reference_voltage_v": 0.094125,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.0965,
+          "reference_voltage_v": 0.09875,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.10125,
+          "reference_voltage_v": 0.10375,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.10625,
+          "reference_voltage_v": 0.108875,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.114,
+          "reference_voltage_v": 0.117,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.119625,
+          "reference_voltage_v": 0.12275,
+          "steady_sample_count": 410
+        },
+        {
+          "raw_voltage_v": 0.125375,
+          "reference_voltage_v": 0.12875,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.1315,
+          "reference_voltage_v": 0.135,
+          "steady_sample_count": 402
+        },
+        {
+          "raw_voltage_v": 0.137875,
+          "reference_voltage_v": 0.14175,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 0.144625,
+          "reference_voltage_v": 0.148625,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.151625,
+          "reference_voltage_v": 0.156,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.159,
+          "reference_voltage_v": 0.163625,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.166625,
+          "reference_voltage_v": 0.1715,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.17475,
+          "reference_voltage_v": 0.179875,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.183125,
+          "reference_voltage_v": 0.1885,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.191625,
+          "reference_voltage_v": 0.1975,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.200875,
+          "reference_voltage_v": 0.206875,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.2105,
+          "reference_voltage_v": 0.216625,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 0.2205,
+          "reference_voltage_v": 0.227,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.2315,
+          "reference_voltage_v": 0.238125,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 0.242625,
+          "reference_voltage_v": 0.24975,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.25425,
+          "reference_voltage_v": 0.2615,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 0.26625,
+          "reference_voltage_v": 0.27375,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.278125,
+          "reference_voltage_v": 0.286,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.291375,
+          "reference_voltage_v": 0.2995,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.312375,
+          "reference_voltage_v": 0.321,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.327375,
+          "reference_voltage_v": 0.33625,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.34275,
+          "reference_voltage_v": 0.352,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.35875,
+          "reference_voltage_v": 0.368375,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 0.37575,
+          "reference_voltage_v": 0.38575,
+          "steady_sample_count": 383
+        },
+        {
+          "raw_voltage_v": 0.393375,
+          "reference_voltage_v": 0.403875,
+          "steady_sample_count": 417
+        },
+        {
+          "raw_voltage_v": 0.412,
+          "reference_voltage_v": 0.42275,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.4315,
+          "reference_voltage_v": 0.44275,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.4515,
+          "reference_voltage_v": 0.46325,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.472625,
+          "reference_voltage_v": 0.484875,
+          "steady_sample_count": 408
+        },
+        {
+          "raw_voltage_v": 0.49475,
+          "reference_voltage_v": 0.5075,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.518125,
+          "reference_voltage_v": 0.53125,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.54225,
+          "reference_voltage_v": 0.556,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 0.567625,
+          "reference_voltage_v": 0.581875,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.594,
+          "reference_voltage_v": 0.60875,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.622,
+          "reference_voltage_v": 0.637375,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.65125,
+          "reference_voltage_v": 0.66725,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.681875,
+          "reference_voltage_v": 0.698375,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.71375,
+          "reference_voltage_v": 0.730875,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.749375,
+          "reference_voltage_v": 0.767,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.80225,
+          "reference_voltage_v": 0.82075,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.839375,
+          "reference_voltage_v": 0.8585,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.876,
+          "reference_voltage_v": 0.896125,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.916625,
+          "reference_voltage_v": 0.9375,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.95875,
+          "reference_voltage_v": 0.98025,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 1.003,
+          "reference_voltage_v": 1.02525,
+          "steady_sample_count": 401
+        },
+        {
+          "raw_voltage_v": 1.049625,
+          "reference_voltage_v": 1.073,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 1.098125,
+          "reference_voltage_v": 1.12225,
+          "steady_sample_count": 408
+        },
+        {
+          "raw_voltage_v": 1.14925,
+          "reference_voltage_v": 1.174125,
+          "steady_sample_count": 393
+        },
+        {
+          "raw_voltage_v": 1.2025,
+          "reference_voltage_v": 1.2285,
+          "steady_sample_count": 387
+        },
+        {
+          "raw_voltage_v": 1.2585,
+          "reference_voltage_v": 1.285375,
+          "steady_sample_count": 415
+        },
+        {
+          "raw_voltage_v": 1.318,
+          "reference_voltage_v": 1.345875,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 1.379,
+          "reference_voltage_v": 1.408125,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 1.443375,
+          "reference_voltage_v": 1.473875,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 1.51025,
+          "reference_voltage_v": 1.5411875,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 1.580125,
+          "reference_voltage_v": 1.612375,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 1.653875,
+          "reference_voltage_v": 1.68725,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 1.7305,
+          "reference_voltage_v": 1.765,
+          "steady_sample_count": 392
+        },
+        {
+          "raw_voltage_v": 1.81025,
+          "reference_voltage_v": 1.8461875,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 1.89425,
+          "reference_voltage_v": 1.931375,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 1.9815,
+          "reference_voltage_v": 2.01975,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 2.12025,
+          "reference_voltage_v": 2.1605,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 2.21875,
+          "reference_voltage_v": 2.2600625,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 2.322,
+          "reference_voltage_v": 2.364875,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 2.43025,
+          "reference_voltage_v": 2.4745,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 2.5425,
+          "reference_voltage_v": 2.588,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 2.66,
+          "reference_voltage_v": 2.707625,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 2.783875,
+          "reference_voltage_v": 2.833,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 2.911,
+          "reference_voltage_v": 2.963125,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 3.0283125,
+          "reference_voltage_v": 3.08325,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 3.138875,
+          "reference_voltage_v": 3.182375,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 3.22925,
+          "reference_voltage_v": 3.264125,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 3.306125,
+          "reference_voltage_v": 3.33775,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 3.3730625,
+          "reference_voltage_v": 3.402125,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 3.43975,
+          "reference_voltage_v": 3.466625,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 3.5015,
+          "reference_voltage_v": 3.526625,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 3.55975,
+          "reference_voltage_v": 3.58275,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 3.613375,
+          "reference_voltage_v": 3.6355,
+          "steady_sample_count": 400
+        }
+      ]
+    },
+    {
+      "channel": "ADC2",
+      "input_min_v": 0.0135,
+      "input_max_v": 3.6355,
+      "nodes": [
+        {
+          "raw_voltage_v": 0.0135,
+          "reference_voltage_v": 0.01225,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.014125,
+          "reference_voltage_v": 0.013,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.014875,
+          "reference_voltage_v": 0.01375,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.01575,
+          "reference_voltage_v": 0.0145,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.016625,
+          "reference_voltage_v": 0.015375,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.0175,
+          "reference_voltage_v": 0.01625,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.0185,
+          "reference_voltage_v": 0.017125,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.0195,
+          "reference_voltage_v": 0.018125,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.0205,
+          "reference_voltage_v": 0.019125,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 0.021625,
+          "reference_voltage_v": 0.02025,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.02275,
+          "reference_voltage_v": 0.021375,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.024,
+          "reference_voltage_v": 0.022625,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.025625,
+          "reference_voltage_v": 0.024125,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.027125,
+          "reference_voltage_v": 0.025625,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.028625,
+          "reference_voltage_v": 0.027125,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.03025,
+          "reference_voltage_v": 0.028625,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.031875,
+          "reference_voltage_v": 0.030375,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.0335,
+          "reference_voltage_v": 0.031875,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.03475,
+          "reference_voltage_v": 0.03325,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 0.0365,
+          "reference_voltage_v": 0.035,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.0385,
+          "reference_voltage_v": 0.036875,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.0415,
+          "reference_voltage_v": 0.04,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.043625,
+          "reference_voltage_v": 0.042125,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.045875,
+          "reference_voltage_v": 0.044375,
+          "steady_sample_count": 393
+        },
+        {
+          "raw_voltage_v": 0.048125,
+          "reference_voltage_v": 0.046625,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.0505,
+          "reference_voltage_v": 0.049125,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.053125,
+          "reference_voltage_v": 0.05175,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.055875,
+          "reference_voltage_v": 0.0545,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.058625,
+          "reference_voltage_v": 0.05725,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.061625,
+          "reference_voltage_v": 0.06025,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.064625,
+          "reference_voltage_v": 0.063375,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.067875,
+          "reference_voltage_v": 0.066625,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.07125,
+          "reference_voltage_v": 0.07,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.075,
+          "reference_voltage_v": 0.07375,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.07875,
+          "reference_voltage_v": 0.0775,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.082625,
+          "reference_voltage_v": 0.0815,
+          "steady_sample_count": 400
+        },
+        {
+          "raw_voltage_v": 0.0865,
+          "reference_voltage_v": 0.085375,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.09075,
+          "reference_voltage_v": 0.089625,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.095125,
+          "reference_voltage_v": 0.094125,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.099875,
+          "reference_voltage_v": 0.09875,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.10475,
+          "reference_voltage_v": 0.10375,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.10975,
+          "reference_voltage_v": 0.108875,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.117875,
+          "reference_voltage_v": 0.117,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.1235,
+          "reference_voltage_v": 0.12275,
+          "steady_sample_count": 410
+        },
+        {
+          "raw_voltage_v": 0.1295,
+          "reference_voltage_v": 0.12875,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.13575,
+          "reference_voltage_v": 0.135,
+          "steady_sample_count": 402
+        },
+        {
+          "raw_voltage_v": 0.14225,
+          "reference_voltage_v": 0.14175,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 0.149125,
+          "reference_voltage_v": 0.148625,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.156375,
+          "reference_voltage_v": 0.156,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.163875,
+          "reference_voltage_v": 0.163625,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.17175,
+          "reference_voltage_v": 0.1715,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 0.18,
+          "reference_voltage_v": 0.179875,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.188625,
+          "reference_voltage_v": 0.1885,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.1975,
+          "reference_voltage_v": 0.1975,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.206875,
+          "reference_voltage_v": 0.206875,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.216625,
+          "reference_voltage_v": 0.216625,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 0.227,
+          "reference_voltage_v": 0.227,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.238125,
+          "reference_voltage_v": 0.238125,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 0.24975,
+          "reference_voltage_v": 0.24975,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.2615,
+          "reference_voltage_v": 0.2615,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 0.27375,
+          "reference_voltage_v": 0.27375,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.286,
+          "reference_voltage_v": 0.286,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.2995,
+          "reference_voltage_v": 0.2995,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.321,
+          "reference_voltage_v": 0.321,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.33625,
+          "reference_voltage_v": 0.33625,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.352,
+          "reference_voltage_v": 0.352,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.368375,
+          "reference_voltage_v": 0.368375,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 0.38575,
+          "reference_voltage_v": 0.38575,
+          "steady_sample_count": 383
+        },
+        {
+          "raw_voltage_v": 0.403875,
+          "reference_voltage_v": 0.403875,
+          "steady_sample_count": 417
+        },
+        {
+          "raw_voltage_v": 0.42275,
+          "reference_voltage_v": 0.42275,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.44275,
+          "reference_voltage_v": 0.44275,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.46325,
+          "reference_voltage_v": 0.46325,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 0.484875,
+          "reference_voltage_v": 0.484875,
+          "steady_sample_count": 408
+        },
+        {
+          "raw_voltage_v": 0.5075,
+          "reference_voltage_v": 0.5075,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.53125,
+          "reference_voltage_v": 0.53125,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 0.556,
+          "reference_voltage_v": 0.556,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 0.581875,
+          "reference_voltage_v": 0.581875,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.60875,
+          "reference_voltage_v": 0.60875,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 0.637375,
+          "reference_voltage_v": 0.637375,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.66725,
+          "reference_voltage_v": 0.66725,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 0.698375,
+          "reference_voltage_v": 0.698375,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.730875,
+          "reference_voltage_v": 0.730875,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.767,
+          "reference_voltage_v": 0.767,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 0.82075,
+          "reference_voltage_v": 0.82075,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.8585,
+          "reference_voltage_v": 0.8585,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 0.896125,
+          "reference_voltage_v": 0.896125,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 0.9375,
+          "reference_voltage_v": 0.9375,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 0.98025,
+          "reference_voltage_v": 0.98025,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 1.02525,
+          "reference_voltage_v": 1.02525,
+          "steady_sample_count": 401
+        },
+        {
+          "raw_voltage_v": 1.073,
+          "reference_voltage_v": 1.073,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 1.12225,
+          "reference_voltage_v": 1.12225,
+          "steady_sample_count": 408
+        },
+        {
+          "raw_voltage_v": 1.174125,
+          "reference_voltage_v": 1.174125,
+          "steady_sample_count": 393
+        },
+        {
+          "raw_voltage_v": 1.2285,
+          "reference_voltage_v": 1.2285,
+          "steady_sample_count": 387
+        },
+        {
+          "raw_voltage_v": 1.285375,
+          "reference_voltage_v": 1.285375,
+          "steady_sample_count": 415
+        },
+        {
+          "raw_voltage_v": 1.345875,
+          "reference_voltage_v": 1.345875,
+          "steady_sample_count": 403
+        },
+        {
+          "raw_voltage_v": 1.408125,
+          "reference_voltage_v": 1.408125,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 1.473875,
+          "reference_voltage_v": 1.473875,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 1.5411875,
+          "reference_voltage_v": 1.5411875,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 1.612375,
+          "reference_voltage_v": 1.612375,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 1.68725,
+          "reference_voltage_v": 1.68725,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 1.765,
+          "reference_voltage_v": 1.765,
+          "steady_sample_count": 392
+        },
+        {
+          "raw_voltage_v": 1.8461875,
+          "reference_voltage_v": 1.8461875,
+          "steady_sample_count": 406
+        },
+        {
+          "raw_voltage_v": 1.931375,
+          "reference_voltage_v": 1.931375,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 2.01975,
+          "reference_voltage_v": 2.01975,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 2.1605,
+          "reference_voltage_v": 2.1605,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 2.2600625,
+          "reference_voltage_v": 2.2600625,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 2.364875,
+          "reference_voltage_v": 2.364875,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 2.4745,
+          "reference_voltage_v": 2.4745,
+          "steady_sample_count": 398
+        },
+        {
+          "raw_voltage_v": 2.588,
+          "reference_voltage_v": 2.588,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 2.707625,
+          "reference_voltage_v": 2.707625,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 2.833,
+          "reference_voltage_v": 2.833,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 2.963125,
+          "reference_voltage_v": 2.963125,
+          "steady_sample_count": 395
+        },
+        {
+          "raw_voltage_v": 3.08325,
+          "reference_voltage_v": 3.08325,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 3.182375,
+          "reference_voltage_v": 3.182375,
+          "steady_sample_count": 407
+        },
+        {
+          "raw_voltage_v": 3.264125,
+          "reference_voltage_v": 3.264125,
+          "steady_sample_count": 396
+        },
+        {
+          "raw_voltage_v": 3.33775,
+          "reference_voltage_v": 3.33775,
+          "steady_sample_count": 405
+        },
+        {
+          "raw_voltage_v": 3.402125,
+          "reference_voltage_v": 3.402125,
+          "steady_sample_count": 394
+        },
+        {
+          "raw_voltage_v": 3.466625,
+          "reference_voltage_v": 3.466625,
+          "steady_sample_count": 399
+        },
+        {
+          "raw_voltage_v": 3.526625,
+          "reference_voltage_v": 3.526625,
+          "steady_sample_count": 397
+        },
+        {
+          "raw_voltage_v": 3.58275,
+          "reference_voltage_v": 3.58275,
+          "steady_sample_count": 404
+        },
+        {
+          "raw_voltage_v": 3.6355,
+          "reference_voltage_v": 3.6355,
+          "steady_sample_count": 400
+        }
+      ]
+    }
+  ],
+  "validation": {
+    "relative_spread_definition": "100*(max-min)/median",
+    "minimum_raw_median_voltage_v": 0.05,
+    "all_qualified_samples": {
+      "sample_count": 752,
+      "median_relative_spread_pct": 0.032970830497815615,
+      "p95_relative_spread_pct": 0.16949152542372897,
+      "max_relative_spread_pct": 0.45861541821358415
+    },
+    "operating_adc_range_v": [
+      2.5,
+      3.0
+    ],
+    "operating_range_samples": {
+      "sample_count": 32,
+      "median_relative_spread_pct": 0.02410791131135689,
+      "p95_relative_spread_pct": 0.06402266152709198,
+      "max_relative_spread_pct": 0.13163329932568463
+    },
+    "low_voltage_range_v": [
+      0.05,
+      0.5
+    ],
+    "low_voltage_absolute_spread": {
+      "sample_count": 376,
+      "median_absolute_spread_v": 0.00012499999999998623,
+      "p95_absolute_spread_v": 0.0002521536632525273,
+      "max_absolute_spread_v": 0.000703616965912035
+    },
+    "instantaneous_sample_diagnostics": {
+      "all_qualified_samples": {
+        "sample_count": 18819,
+        "median_relative_spread_pct": 0.12410512396701716,
+        "p95_relative_spread_pct": 0.444119082479258,
+        "max_relative_spread_pct": 2.8058200468148122
+      },
+      "operating_range_samples": {
+        "sample_count": 812,
+        "median_relative_spread_pct": 0.10611277292326307,
+        "p95_relative_spread_pct": 0.3700680447619768,
+        "max_relative_spread_pct": 1.7374783464036185
+      }
+    },
+    "excluded_endpoint_platforms": 2
+  }
+}

--- a/robots/robotic_fish_io/config/io.yaml
+++ b/robots/robotic_fish_io/config/io.yaml
@@ -14,7 +14,7 @@ adc:
   calibration:
     enabled: true
     required: true
-    file: calibration/adc_independent_transfer_20260818_183014_calbri01_raw.json
+    file: calibration/adc_independent_transfer_20260901_171408_calbri05_raw.json
 
 dac:
   port: /dev/robotic_fish_dac

--- a/robots/robotic_fish_io/test/test_calibration.py
+++ b/robots/robotic_fish_io/test/test_calibration.py
@@ -17,7 +17,7 @@ CONFIG_PATH = (
     PACKAGE_ROOT
     / "config"
     / "calibration"
-    / "adc_independent_transfer_20260818_183014_calbri01_raw.json"
+    / "adc_independent_transfer_20260901_171408_calbri05_raw.json"
 )
 
 
@@ -29,9 +29,9 @@ class CalibrationTests(unittest.TestCase):
     def test_packaged_curves_are_complete_and_dac_independent(self):
         self.assertEqual(
             self.calibration.calibration_id,
-            "adc_independent_transfer_20260818_183014_calbri01_raw",
+            "adc_independent_transfer_20260901_171408_calbri05_raw",
         )
-        self.assertEqual([len(curve) for curve in self.calibration.curves], [131] * 3)
+        self.assertEqual([len(curve) for curve in self.calibration.curves], [121] * 3)
         self.assertFalse(
             self.calibration.document["processing"]["runtime_dac_dependency"]
         )
@@ -39,7 +39,7 @@ class CalibrationTests(unittest.TestCase):
             self.assertTrue(all(b > a for a, b in zip(raw_nodes, raw_nodes[1:])))
 
     def test_exact_nodes_and_piecewise_linear_interpolation(self):
-        for index in (0, 1, 65, 130):
+        for index in (0, 1, 60, 120):
             raw = [
                 self.calibration.curves[channel][index]["raw_voltage_v"]
                 for channel in range(3)


### PR DESCRIPTION
### What is this

This PR adds ROS interfaces and data logging support for the fish-sonic acoustic module.

It provides timestamped three-channel ADC acquisition, serial DAC control, independent per-channel ADC calibration, optional automatic gain control (AGC), sonic-specific teleoperation, and automatic rosbag recording.

The ADC calibration table is updated using data collected with the current battery-powered acoustic sensing system.

### Details

- `6b017d82`: Add the `robotic_fish_io` package with timestamped ADS1115 ADC sampling, serial DAC control, ROS messages, services, launch configuration, and hardware-independent driver tests.
- `76bac0ea`: Add independent piecewise-linear calibration for all three ADC channels, including schema validation, calibrated output fields, out-of-range fallback behavior, and regression tests.
- `51e59f53`: Add optional closed-loop AGC using the maximum raw ADC voltage to safely adjust the DAC gain. Also add DAC device configuration and AGC tests.
- `e2f4a6fc`: Add `sonic_teleop.py` and `sonic_teleop.launch` for manual and automatic fish-sonic servo control.
- `c8bfa846`: Add automatic rosbag recording to the sonic launch workflow and update the default ADC calibration to `adc_independent_transfer_20260901_171408_calbri05_raw.json`.

The rosbag recorder stores the following topics:

- `/robotic_fish/adc/samples`
- `/robotic_fish/dac/command`
- `/robotic_fish/dac/state`
- `/diagnostics`
- `/joy`
- `/imu`
- `/servo/target_states`
- `/servo/states`

The recorded ADC messages contain the raw voltage, calibrated voltage, calibration ID, calibration status, and individual conversion timestamps.

### Testing

- All 22 `robotic_fish_io` unit tests pass.
- The sonic launch configuration was verified with ADC, DAC, and rosbag nodes enabled.
- All recorded ADC samples used the new `calbri05` calibration successfully.
- ADC and DAC diagnostics reported normal operation.