### PR TITLE
[fish-sonic][sensors] Add acoustic module driver and safe gain control

### DIFF
--- a/robots/robotic_fish/launch/record.launch
+++ b/robots/robotic_fish/launch/record.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="enabled" default="true"/>
-  <arg name="bag_prefix" default="$(env HOME)/sonic_"/>
+  <arg name="bag_prefix" default="$(env HOME)/sonic"/>
 
   <node if="$(arg enabled)"
         pkg="rosbag"
@@ -12,6 +12,7 @@
               /robotic_fish/adc/samples
               /robotic_fish/dac/command
               /robotic_fish/dac/state
+              /robotic_fish/gain_control/state
               /diagnostics
               /joy
               /imu

--- a/robots/robotic_fish_io/CMakeLists.txt
+++ b/robots/robotic_fish_io/CMakeLists.txt
@@ -15,6 +15,7 @@ add_message_files(
   FILES
   AdcSample.msg
   AdcSampleArray.msg
+  GainControlState.msg
 )
 
 add_service_files(

--- a/robots/robotic_fish_io/README.md
+++ b/robots/robotic_fish_io/README.md
@@ -1,30 +1,148 @@
 # robotic_fish_io
 
-ROS 1 hardware interface for the robotic fish ADS1115 ADC and serial DAC.
+`robotic_fish_io` is the ROS 1 hardware-interface package for the robotic fish acoustic acquisition system. It provides:
 
-## ADC timing
+- timestamped acquisition of ADC0, ADC1, and ADC2 through an ADS1115;
+- independent transfer-curve calibration for each ADC channel;
+- serial DAC output for the LNA gain-control voltage;
+- fixed-voltage and closed-loop gain control;
+- prioritized DAC reduction when a raw ADC voltage becomes unsafe;
+- diagnostics and observable state suitable for rosbag recording.
 
-The ADS1115 multiplexes its input channels and converts them sequentially. The
-node records a separate conversion start, conversion end, and midpoint timestamp
-for every `AdcSample`. Samples are published after the three-channel calibration
-decision, but their timestamps still describe the individual hardware
-conversions accurately. The optional `/robotic_fish/adc/samples` batch retains
-the same per-sample timestamps.
+This package is responsible only for sensor IO and gain control. Robotic-fish motion control belongs to `robotic_fish`, and communication with the embedded controller belongs to `spinal`.
 
-Each sample contains both `voltage` (the direct ADS1115 conversion) and
-`calibrated_voltage`. Calibration is loaded from the JSON file selected under
-`adc.calibration.file` in `config/io.yaml`. The packaged default is the validated
-three-channel independent transfer table
-`adc_independent_transfer_20260901_171408_calbri05_raw.json`.
+## 1. System relationship
 
-ADC0, ADC1, and ADC2 each use their own raw ADC voltage to query a piecewise
-linear curve. Calibration has no runtime dependency on the DAC voltage. If any
-channel is outside its observed input range (including the configured endpoint
-tolerance), the complete three-channel group falls back to raw voltages and
-`calibration_applied` is false. The node never extrapolates or mixes calibrated
-and raw values within a group.
+```text
+ADS1115 ──I2C──> /adc ──AdcSampleArray──> /gain_control
+                   │                            │
+                   │                            └──SetDacVoltage──> /dac ──serial──> DAC/LNA
+                   │                                                   │
+                   └──snapshot the latest confirmed DAC voltage <─────┘
 
-Select a packaged calibration file relative to the package `config` directory:
+/joy ──> /sonic_teleop_node ──> /servo/target_states ──> /rosserial_server ──> MCU
+```
+
+The gain-control node never accesses the DAC serial port directly. `/dac` is the only node that writes to the DAC hardware. `/gain_control` requests voltages through a ROS service and updates its state using the confirmed value published on `/robotic_fish/dac/state`.
+
+## 2. ROS nodes
+
+| Node | Executable | Responsibility |
+| --- | --- | --- |
+| `/adc` | `adc_node.py` | ADC acquisition, calibration, timestamps, and diagnostics |
+| `/dac` | `dac_node.py` | DAC serial access, voltage validation, state feedback, and shutdown safety |
+| `/gain_control` | `agc_node.py` | Off, fixed, and closed-loop modes plus ADC overrange protection |
+
+The default command is:
+
+```bash
+roslaunch robotic_fish_io sensor_io.launch
+```
+
+It starts all three nodes. `/gain_control` starts in `off` mode, but its ADC overrange protection remains active. To omit the controller completely:
+
+```bash
+roslaunch robotic_fish_io sensor_io.launch enable_gain_control:=false
+```
+
+## 3. Launch files
+
+### 3.1 Package-only launch: `sensor_io.launch`
+
+Use this launch file to test the ADC, DAC, and gain controller without starting spinal:
+
+```bash
+roslaunch robotic_fish_io sensor_io.launch gain_mode:=off
+```
+
+ADC only:
+
+```bash
+roslaunch robotic_fish_io sensor_io.launch \
+  enable_adc:=true enable_dac:=false
+```
+
+DAC only:
+
+```bash
+roslaunch robotic_fish_io sensor_io.launch \
+  enable_adc:=false enable_dac:=true
+```
+
+`/gain_control` is not started if either the ADC or DAC node is disabled.
+
+### 3.2 IO and embedded bridge: `io.launch`
+
+```bash
+roslaunch robotic_fish_io io.launch dev:=vim4 gain_mode:=off
+```
+
+In addition to the three package nodes, this launch file includes:
+
+```text
+spinal/launch/bridge.launch
+```
+
+Serial mode on the VIM4 starts `/rosserial_server` with:
+
+```text
+/dev/ttyS4
+921600 baud
+```
+
+Use `sensor_io.launch` when spinal is not needed. Otherwise, an unavailable embedded controller will cause repeated `Sync with device lost` warnings even if the ADC and DAC nodes are operating correctly.
+
+### 3.3 Common launch arguments
+
+| Argument | Default | Description |
+| --- | ---: | --- |
+| `enable_adc` | `true` | Start the ADC node |
+| `enable_dac` | `true` | Start the DAC node |
+| `enable_gain_control` | `true` | Start gain control when both ADC and DAC are enabled |
+| `gain_mode` | `off` | Select `off`, `fixed`, or `closed_loop` |
+| `fixed_gain_voltage` | `0.0` | Target DAC voltage in fixed mode |
+| `agc_target_min_v` | `2.5` | Lower raw-ADC target in closed-loop mode |
+| `agc_target_max_v` | `3.0` | Upper raw-ADC target in closed-loop mode |
+| `agc_step_v` | `0.01` | Normal closed-loop DAC adjustment step |
+| `adc_safety_limit_v` | `3.50` | Raw-ADC software safety threshold |
+| `enable_agc` | `false` | Deprecated compatibility argument; `true` selects closed-loop mode |
+
+New launch commands should use `gain_mode`. Do not combine `enable_agc:=true` with fixed mode.
+
+## 4. ADC acquisition and calibration
+
+### 4.1 Default hardware configuration
+
+| Setting | Default |
+| --- | --- |
+| I2C device | `/dev/i2c-0` |
+| ADS1115 address | `0x48` |
+| Channels | `0, 1, 2` |
+| Data rate | `128 SPS` |
+| Target group rate per channel | `20 Hz` |
+| Full-scale range | ADS1115 driver configuration of `±4.096 V` |
+
+The ADS1115 multiplexes and converts the three channels sequentially. A complete three-channel group is published at approximately 20 Hz, while the combined rate of the individual-sample topic is approximately 60 Hz.
+
+### 4.2 Timestamps
+
+Every `AdcSample` has its own:
+
+- `conversion_start`: start of that channel's conversion;
+- `conversion_end`: completion of that channel's conversion;
+- `header.stamp`: midpoint of the conversion window.
+
+Although three samples are published together in an `AdcSampleArray`, they retain their individual hardware timing. The three channels must not be interpreted as simultaneous conversions.
+
+### 4.3 Calibration file
+
+The current default calibration is:
+
+```text
+config/calibration/adc_independent_transfer_20260901_171408_calbri05_raw.json
+```
+
+It is selected in `config/io.yaml`:
 
 ```yaml
 adc:
@@ -34,94 +152,298 @@ adc:
     file: calibration/adc_independent_transfer_20260901_171408_calbri05_raw.json
 ```
 
-An absolute path is also accepted. With `required: true`, a missing, malformed,
-DAC-dependent, or otherwise incompatible calibration file prevents the ADC node
-from starting instead of silently using an invalid calibration.
+A relative path is resolved against this package's `config/` directory. An absolute path is also accepted. With `required: true`, a missing, malformed, or incompatible calibration file prevents the ADC node from starting instead of silently using invalid calibration data.
 
-Default ADC configuration:
+ADC0, ADC1, and ADC2 each use their own piecewise-linear transfer curve. The calibration does not use DAC voltage as an input and never extrapolates beyond its observed range. If any channel in a group is outside the calibration range, the entire group falls back to raw voltages:
 
-- I2C bus: `0`
-- address: `0x48`
-- channels: `0, 1, 2`
-- ADS1115 data rate: `128 SPS`
-- target update rate per channel: `20 Hz`
-
-## Closed-loop AGC
-
-The optional AGC node reads complete `/robotic_fish/adc/samples` batches and
-always makes its decision from the maximum of the three raw `voltage` fields.
-It deliberately ignores `calibrated_voltage`, so calibration or filtering does
-not alter clipping protection or gain control.
-
-The default configuration keeps the maximum raw ADC voltage between 2.50 V and
-3.00 V. Three consecutive groups below the range increase the DAC by 0.01 V;
-three consecutive groups above the range decrease it by 0.01 V. Adjustments are
-at least 0.50 seconds apart and are clamped to the configured 0.00-5.00 V DAC
-range. A group inside the target range or an invalid/incomplete group clears the
-consecutive counters.
-
-AGC hardware control is opt-in at launch:
-
-```bash
-roslaunch robotic_fish_io sensor_io.launch enable_agc:=true
+```text
+calibration_applied = false
+calibrated_voltage = voltage
 ```
 
-When no latched DAC state exists, the AGC node first applies `start_voltage`
-(0.00 V by default) through `/robotic_fish/dac/set_voltage`. Subsequent changes
-also use this service and only accept its confirmed applied voltage. Runtime
-control is available through:
+This prevents calibrated and uncalibrated values from being mixed within one three-channel group.
+
+### 4.4 `AdcSample` fields
+
+| Field | Meaning |
+| --- | --- |
+| `channel` | ADC channel number |
+| `raw` | Signed ADS1115 conversion count |
+| `voltage` | Voltage directly converted from the ADS1115 count |
+| `calibrated_voltage` | Transfer-curve result; equal to `voltage` when calibration is inactive |
+| `calibration_gain` | Calibration ratio at the current interpolation point |
+| `calibration_applied` | Whether calibration was applied to the complete three-channel group |
+| `calibration_id` | Identifier of the active calibration |
+| `gain_control_voltage` | Latest confirmed DAC control voltage when this conversion started |
+| `gain_control_voltage_valid` | Whether a valid `/robotic_fish/dac/state` has been received |
+| `conversion_start` | Conversion start time |
+| `conversion_end` | Conversion completion time |
+
+`gain_control_voltage` is the actual DAC voltage applied to the analog gain-control input. It is not an LNA gain ratio. A separate voltage-to-gain calibration is required before physical gain can be reported.
+
+## 5. DAC control
+
+Default configuration:
+
+| Setting | Default |
+| --- | --- |
+| Serial device | `/dev/robotic_fish_dac` |
+| Baud rate | `19200` |
+| Channel | `1` |
+| Voltage range | `0.00–5.00 V` |
+| Resolution | `0.01 V` |
+| Echo verification | Enabled |
+| Safe shutdown voltage | `0.00 V` |
+
+Set DAC channel 1 to 0 V:
 
 ```bash
-rosservice call /robotic_fish/agc/enable "data: false"
-rosservice call /robotic_fish/agc/enable "data: true"
+rosservice call /robotic_fish/dac/set_voltage \
+  "channel: 1
+voltage: 0.0"
 ```
 
-AGC status, current raw ADC maximum, DAC voltage, consecutive counters,
-adjustment count, and errors are published through `/diagnostics`. Avoid other
-DAC command publishers while AGC is enabled, and leave the DAC command watchdog
-disabled (`command_timeout: 0.0`) unless its timeout is intentionally coordinated
-with the AGC update behavior.
+Example successful response:
 
-## Starting the nodes
+```text
+success: True
+applied_voltage: 0.0
+```
+
+A `std_msgs/Float32` command can also be published to `/robotic_fish/dac/command`. Do not use another DAC command source while fixed or closed-loop control is active, because the sources would overwrite one another.
+
+Non-numeric values, NaN, Inf, voltages below 0 V, and voltages above 5 V are rejected. On a normal shutdown, `zero_on_shutdown: true` makes the node attempt to apply `safe_voltage`, which defaults to 0 V.
+
+## 6. LNA gain control
+
+All gain-control decisions use the maximum raw voltage in a complete ADC group:
+
+```text
+adc_max_raw_voltage = max(ADC0.voltage, ADC1.voltage, ADC2.voltage)
+```
+
+The controller deliberately ignores `calibrated_voltage`, so clipping protection does not depend on calibration validity or calibration-file contents.
+
+### 6.1 `off` mode
 
 ```bash
-roslaunch robotic_fish_io sensor_io.launch
+roslaunch robotic_fish_io sensor_io.launch gain_mode:=off
 ```
 
-ADC only:
+Normal fixed or closed-loop adjustment is disabled, but the controller continues to monitor the ADC safety threshold. If the DAC state is known and an overrange occurs, safety logic can still lower the DAC. If no DAC state is available and an overrange is detected, the controller requests the configured DAC minimum.
+
+### 6.2 `fixed` mode
 
 ```bash
-roslaunch robotic_fish_io sensor_io.launch enable_dac:=false
+roslaunch robotic_fish_io sensor_io.launch \
+  gain_mode:=fixed \
+  fixed_gain_voltage:=0.20
 ```
 
-DAC only:
+The default ramp changes the DAC by 0.05 V every 0.10 seconds instead of jumping directly to the target:
+
+```text
+0.00 → 0.05 → 0.10 → 0.15 → 0.20 V
+```
+
+The state becomes `fixed_holding` after reaching the target. Start real-hardware tests at a low voltage; do not begin by commanding 5 V.
+
+### 6.3 `closed_loop` mode
 
 ```bash
-roslaunch robotic_fish_io sensor_io.launch enable_adc:=false
+roslaunch robotic_fish_io sensor_io.launch \
+  gain_mode:=closed_loop \
+  agc_target_min_v:=2.50 \
+  agc_target_max_v:=3.00 \
+  agc_step_v:=0.01
 ```
 
-Inspect ADC samples:
+Default behavior:
+
+```text
+maximum raw ADC < 2.50 V for 3 consecutive groups: increase DAC by 0.01 V
+2.50 V <= maximum raw ADC <= 3.00 V: hold
+maximum raw ADC > 3.00 V for 3 consecutive groups: decrease DAC by 0.01 V
+minimum interval between normal adjustments: 0.50 s
+```
+
+The upper ADC target must be strictly below the safety threshold. Both the normal closed-loop step and the fixed-mode ramp step must not exceed `max_normal_step_v`, which defaults to 0.10 V.
+
+### 6.4 ADC software safety protection
+
+Default thresholds:
+
+| Parameter | Default |
+| --- | ---: |
+| Trigger threshold `adc_safety_limit_v` | `3.50 V` |
+| Recovery threshold `adc_safety_recovery_v` | `3.30 V` |
+| Safety reduction step `safety_step_v` | `0.10 V` |
+| Safety adjustment interval `safety_interval_s` | `0.10 s` |
+
+When any raw ADC channel reaches or exceeds 3.50 V:
+
+1. normal consecutive-sample counting and the normal AGC interval are bypassed;
+2. the DAC is reduced by 0.10 V every 0.10 seconds;
+3. reduction continues until the maximum raw ADC voltage is at or below 3.30 V;
+4. every command remains clamped to the 0–5 V DAC range.
+
+After an overrange in fixed mode, the controller enters `fixed_limited` and does not automatically ramp back to the original fixed target. Reset the latch only after the cause of the overrange has been checked:
 
 ```bash
-rostopic echo /robotic_fish/adc/sample
-rostopic hz /robotic_fish/adc/sample
+rosservice call /robotic_fish/gain_control/reset_safety
 ```
 
-Set DAC channel 1 to 1.25 V:
+Closed-loop mode waits 0.20 seconds after recovery, clears its counters, and then resumes normal control. If the DAC has reached 0 V while the ADC remains above the recovery threshold, the state becomes:
+
+```text
+adc_overrange_at_dac_min
+```
+
+Voltage increases remain blocked, and an error is reported through `/diagnostics`.
+
+The controller never increases DAC voltage when ADC data is stale, incomplete, non-finite, or when the DAC state or DAC service is invalid.
+
+> Software protection can react only after an overrange has been sampled. It cannot prevent electrical transients between samples. Hardware clamping or input protection is still required at the ADC input.
+
+### 6.5 Advanced parameters
+
+Advanced settings are under `gain_control` in `config/io.yaml`:
+
+| Parameter | Default | Description |
+| --- | ---: | --- |
+| `dac_min_v` | `0.0` | Minimum DAC voltage allowed by the controller |
+| `dac_max_v` | `5.0` | Maximum DAC voltage allowed by the controller |
+| `max_normal_step_v` | `0.10` | Maximum allowed non-safety adjustment step |
+| `start_voltage` | `0.0` | Safe initialization voltage when no DAC state exists |
+| `fixed_ramp_step_v` | `0.05` | Fixed-mode ramp step |
+| `fixed_ramp_interval_s` | `0.10` | Fixed-mode ramp interval |
+| `interval_s` | `0.50` | Closed-loop normal adjustment interval |
+| `consecutive_samples` | `3` | Consecutive groups required for a closed-loop adjustment |
+| `recovery_settle_s` | `0.20` | Settling delay after overrange recovery |
+| `adc_timeout` | `1.0` | ADC sample-group validity timeout |
+| `service_timeout` | `1.0` | DAC service wait timeout |
+
+## 7. ROS interfaces
+
+### 7.1 Topics
+
+| Topic | Type | Publisher/subscriber | Content |
+| --- | --- | --- | --- |
+| `/robotic_fish/adc/sample` | `robotic_fish_io/AdcSample` | Published by `/adc` | One channel conversion |
+| `/robotic_fish/adc/samples` | `robotic_fish_io/AdcSampleArray` | Published by `/adc` | Complete three-channel group |
+| `/robotic_fish/dac/command` | `std_msgs/Float32` | Subscribed by `/dac` | External DAC voltage command |
+| `/robotic_fish/dac/state` | `std_msgs/Float32` | Published by `/dac` | Confirmed applied DAC voltage |
+| `/robotic_fish/gain_control/state` | `robotic_fish_io/GainControlState` | Published by `/gain_control` | Mode, action, ADC/DAC, and safety state |
+| `/diagnostics` | `diagnostic_msgs/DiagnosticArray` | Published by all three nodes | Connection, sampling, calibration, control, and error status |
+
+`/robotic_fish/gain_control/state` is latched, so a new subscriber immediately receives the latest state. Unknown numeric values are represented by NaN and must be interpreted together with `adc_valid` and `dac_state_valid`.
+
+### 7.2 Services
+
+| Service | Type | Description |
+| --- | --- | --- |
+| `/robotic_fish/dac/set_voltage` | `robotic_fish_io/SetDacVoltage` | Request and confirm a DAC voltage |
+| `/robotic_fish/gain_control/reset_safety` | `std_srvs/Trigger` | Clear the fixed-mode safety latch; rejected while overrange remains active |
+| `/robotic_fish/agc/enable` | `std_srvs/SetBool` | Compatibility API: true selects closed-loop and false selects off |
+
+### 7.3 Useful inspection commands
 
 ```bash
-rosservice call /robotic_fish/dac/set_voltage "channel: 1
-voltage: 1.25"
+rostopic hz /robotic_fish/adc/samples
+rostopic echo -n 1 /robotic_fish/adc/samples
+rostopic echo /robotic_fish/dac/state
+rostopic echo /robotic_fish/gain_control/state
+rostopic echo /diagnostics
 ```
 
-## Stable DAC device name
+## 8. Full-system startup
 
-The DAC configuration uses `/dev/robotic_fish_dac`. On the VIM4 used for this
-project, the DAC is a CH340 adapter (`1a86:7523`) connected to the dedicated USB
-hub port `1-1.2`. Do not configure `/dev/ttyUSB0` directly: its number can
-change, and another CH340 adapter may belong to the spinal bridge.
+The current system uses three independent launch files. Run them in separate terminals.
 
-Install the packaged physical-port-specific udev rule:
+Terminal 1 — embedded bridge, ADC, DAC, and gain control:
+
+```bash
+source /home/khadas/ros/jsk_aerial_robot_ws/devel/setup.bash
+roslaunch robotic_fish_io io.launch \
+  dev:=vim4 \
+  gain_mode:=fixed \
+  fixed_gain_voltage:=0.20
+```
+
+Terminal 2 — joystick and sonic motion control:
+
+```bash
+source /home/khadas/ros/jsk_aerial_robot_ws/devel/setup.bash
+roslaunch robotic_fish sonic_teleop.launch
+```
+
+Terminal 3 — rosbag recording:
+
+```bash
+source /home/khadas/ros/jsk_aerial_robot_ws/devel/setup.bash
+roslaunch robotic_fish record.launch
+```
+
+`sonic_teleop` can publish a servo target as soon as joystick messages arrive. Secure the fish, keep the tail motion area clear, and verify stable spinal communication before starting the full system.
+
+## 9. Rosbag recording
+
+`robots/robotic_fish/launch/record.launch` currently records:
+
+```text
+/robotic_fish/adc/samples
+/robotic_fish/dac/command
+/robotic_fish/dac/state
+/robotic_fish/gain_control/state
+/diagnostics
+/joy
+/imu
+/servo/target_states
+/servo/states
+```
+
+Start recording with:
+
+```bash
+roslaunch robotic_fish record.launch
+```
+
+The default output filename is similar to:
+
+```text
+/home/khadas/sonic_2026-09-02-19-30-15.bag
+```
+
+While recording, the file has a `.bag.active` suffix. Press Ctrl+C to close it normally and produce the final `.bag` file. Do not power off the computer while the bag is active.
+
+Inspect a recording:
+
+```bash
+rosbag info /home/khadas/sonic_TIMESTAMP.bag
+rosbag check /home/khadas/sonic_TIMESTAMP.bag
+```
+
+Replay it with:
+
+```bash
+rosbag play /home/khadas/sonic_TIMESTAMP.bag
+```
+
+Gain control uses a service to command the DAC, and ROS service requests are not stored as rosbag topics. Reconstruct gain-control behavior primarily from:
+
+```text
+/robotic_fish/dac/state
+/robotic_fish/gain_control/state
+/robotic_fish/adc/samples[*].gain_control_voltage
+```
+
+`/robotic_fish/dac/command` contains only commands sent through the command topic and may have no messages when all voltage changes come from the gain-control service.
+
+## 10. Stable DAC device name
+
+The default device is `/dev/robotic_fish_dac`, avoiding direct dependence on a changing `/dev/ttyUSB0` number. The current VIM4 rule identifies the CH340 adapter (`1a86:7523`) attached to the dedicated USB hub port `1-1.2`.
+
+Install the rule:
 
 ```bash
 source /home/khadas/ros/jsk_aerial_robot_ws/devel/setup.bash
@@ -129,42 +451,120 @@ sudo install -m 0644 \
   "$(rospack find robotic_fish_io)/config/udev/99-robotic-fish-dac.rules" \
   /etc/udev/rules.d/99-robotic-fish-dac.rules
 sudo udevadm control --reload-rules
-sudo udevadm trigger --action=add --subsystem-match=tty \
-  --sysname-match=ttyUSB0
+sudo udevadm trigger --action=add --subsystem-match=tty
 sudo udevadm settle
 ```
 
-The user running ROS must belong to `dialout`. If needed, run the following and
-then log out and back in before starting ROS again:
+The ROS user must belong to `dialout`:
 
 ```bash
+groups
 sudo usermod -aG dialout "$USER"
 ```
 
-Verify the stable link and permissions:
+Log out and back in after changing group membership. Verify the device and permissions:
 
 ```bash
 ls -l /dev/robotic_fish_dac
+readlink -f /dev/robotic_fish_dac
 test -r /dev/robotic_fish_dac && test -w /dev/robotic_fish_dac
 ```
 
-The link should resolve to the current `ttyUSB` device. Keep the DAC adapter in
-USB port `1-1.2`; moving it intentionally prevents this rule from matching, so
-the wrong serial adapter is not driven. To validate the hardware with AGC off,
-start only the DAC node and send a safe 0 V command:
+Keep the DAC adapter connected to the physical USB port encoded in the rule. This prevents the system from accidentally driving another serial adapter used by spinal.
+
+## 11. Troubleshooting
+
+### 11.1 `Sync with device lost`
+
+This warning comes from `/rosserial_server`, not from the ADC, DAC, or gain-control nodes. It means `/dev/ttyS4` could be opened, but a valid rosserial handshake was not received.
+
+Check:
+
+- embedded-controller power and reset state;
+- whether the current spinal firmware is installed;
+- that both host and firmware use 921600 baud;
+- crossed UART TX/RX and a shared ground;
+- the VIM4 UART pinmux/overlay;
+- whether another process owns `/dev/ttyS4`.
+
+Use the package-only launch while testing sensors:
 
 ```bash
-roslaunch robotic_fish_io sensor_io.launch \
-  enable_adc:=false enable_dac:=true enable_agc:=false
-
-rosservice call /robotic_fish/dac/set_voltage "channel: 1
-voltage: 0.0"
+roslaunch robotic_fish_io sensor_io.launch
 ```
 
-A successful response contains `success: True` and `applied_voltage: 0.0`.
-
-## Tests
+### 11.2 `/dev/robotic_fish_dac` does not exist
 
 ```bash
-python3 -m unittest discover -s test -p 'test_*.py' -v
+lsusb
+ls -l /dev/ttyUSB*
+sudo udevadm control --reload-rules
+sudo udevadm trigger --action=add --subsystem-match=tty
 ```
+
+Confirm that the CH340 is connected to the physical port expected by the udev rule and that the user belongs to `dialout`.
+
+### 11.3 `calibration_applied: false`
+
+Common causes are:
+
+- at least one channel is outside the calibration file's observed range;
+- calibration is disabled;
+- the current group does not satisfy the required three-channel configuration.
+
+Inspect `calibration_status` and `calibration_id` in `/diagnostics`.
+
+### 11.4 `adc_stale`
+
+No complete ADC sample group has arrived within `adc_timeout`. The controller will not increase DAC voltage in this state. Check the ADC node, I2C device, and `/robotic_fish/adc/samples` frequency.
+
+### 11.5 `fixed_limited`
+
+Fixed mode previously triggered ADC safety protection. After confirming that the signal is safe, reset the latch:
+
+```bash
+rosservice call /robotic_fish/gain_control/reset_safety
+```
+
+### 11.6 `adc_overrange_at_dac_min`
+
+The DAC has reached 0 V, but the raw ADC voltage remains above the recovery threshold. Do not increase gain. Check input amplitude, analog biasing, the signal chain, and hardware input protection.
+
+## 12. Build and test
+
+Build the package:
+
+```bash
+cd /home/khadas/ros/jsk_aerial_robot_ws
+catkin build robotic_fish_io --no-deps
+source devel/setup.bash
+```
+
+Run the unit tests:
+
+```bash
+cd /home/khadas/ros/jsk_aerial_robot_ws/src/jsk_aerial_robot
+python3 -m unittest discover \
+  -s robots/robotic_fish_io/test \
+  -p 'test_*.py' -v
+```
+
+The current tests cover:
+
+- ADS1115 configuration, conversion, and timeout behavior;
+- DAC 0–5 V limits, BCD commands, and echo verification;
+- independent three-channel calibration and whole-group fallback;
+- fixed-voltage ramping;
+- closed-loop counters, step size, interval, and DAC bounds;
+- 3.50/3.30 V safety triggering and recovery;
+- fixed-mode safety latching;
+- overrange behavior at the minimum DAC voltage.
+
+Recommended first-hardware-test sequence:
+
+1. start with `gain_mode:=off` and inspect ADC data and diagnostics;
+2. explicitly apply 0 V through the DAC service;
+3. begin fixed-mode testing at a low voltage such as 0.20 V;
+4. confirm that reducing DAC voltage actually reduces ADC amplitude during an overrange;
+5. proceed to closed-loop and full-system motion tests;
+6. record a rosbag and inspect the message count of every expected topic after stopping.

--- a/robots/robotic_fish_io/config/io.yaml
+++ b/robots/robotic_fish_io/config/io.yaml
@@ -11,6 +11,7 @@ adc:
   publish_array: true
   sample_topic: /robotic_fish/adc/sample
   samples_topic: /robotic_fish/adc/samples
+  gain_control_topic: /robotic_fish/dac/state
   calibration:
     enabled: true
     required: true
@@ -30,8 +31,9 @@ dac:
   state_topic: /robotic_fish/dac/state
   set_voltage_service: /robotic_fish/dac/set_voltage
 
-agc:
-  enabled: true
+gain_control:
+  mode: "off"
+  fixed_voltage: 0.0
   target_min_v: 2.5
   target_max_v: 3.0
   step_v: 0.01
@@ -39,10 +41,21 @@ agc:
   consecutive_samples: 3
   dac_min_v: 0.0
   dac_max_v: 5.0
+  max_normal_step_v: 0.10
   start_voltage: 0.0
+  fixed_ramp_step_v: 0.05
+  fixed_ramp_interval_s: 0.10
+  adc_safety_limit_v: 3.50
+  adc_safety_recovery_v: 3.30
+  safety_step_v: 0.10
+  safety_interval_s: 0.10
+  recovery_settle_s: 0.20
+  adc_timeout: 1.0
   dac_channel: 1
   service_timeout: 1.0
   adc_samples_topic: /robotic_fish/adc/samples
   dac_state_topic: /robotic_fish/dac/state
   set_voltage_service: /robotic_fish/dac/set_voltage
   enable_service: /robotic_fish/agc/enable
+  reset_safety_service: /robotic_fish/gain_control/reset_safety
+  state_topic: /robotic_fish/gain_control/state

--- a/robots/robotic_fish_io/launch/io.launch
+++ b/robots/robotic_fish_io/launch/io.launch
@@ -5,7 +5,15 @@
   <arg name="config" default="$(find robotic_fish_io)/config/io.yaml"/>
   <arg name="enable_adc" default="true"/>
   <arg name="enable_dac" default="true"/>
+  <arg name="enable_gain_control" default="true"/>
+  <!-- Deprecated compatibility alias. true selects closed_loop. -->
   <arg name="enable_agc" default="false"/>
+  <arg name="gain_mode" default="off"/>
+  <arg name="fixed_gain_voltage" default="0.0"/>
+  <arg name="agc_target_min_v" default="2.5"/>
+  <arg name="agc_target_max_v" default="3.0"/>
+  <arg name="agc_step_v" default="0.01"/>
+  <arg name="adc_safety_limit_v" default="3.50"/>
 
   <include file="$(find spinal)/launch/bridge.launch">
     <arg name="dev" value="$(arg dev)" />
@@ -16,6 +24,13 @@
     <arg name="config" value="$(arg config)"/>
     <arg name="enable_adc" value="$(arg enable_adc)"/>
     <arg name="enable_dac" value="$(arg enable_dac)"/>
+    <arg name="enable_gain_control" value="$(arg enable_gain_control)"/>
     <arg name="enable_agc" value="$(arg enable_agc)"/>
+    <arg name="gain_mode" value="$(arg gain_mode)"/>
+    <arg name="fixed_gain_voltage" value="$(arg fixed_gain_voltage)"/>
+    <arg name="agc_target_min_v" value="$(arg agc_target_min_v)"/>
+    <arg name="agc_target_max_v" value="$(arg agc_target_max_v)"/>
+    <arg name="agc_step_v" value="$(arg agc_step_v)"/>
+    <arg name="adc_safety_limit_v" value="$(arg adc_safety_limit_v)"/>
   </include>
 </launch>

--- a/robots/robotic_fish_io/launch/sensor_io.launch
+++ b/robots/robotic_fish_io/launch/sensor_io.launch
@@ -3,7 +3,15 @@
   <arg name="config" default="$(find robotic_fish_io)/config/io.yaml"/>
   <arg name="enable_adc" default="true"/>
   <arg name="enable_dac" default="true"/>
+  <arg name="enable_gain_control" default="true"/>
+  <!-- Deprecated compatibility alias. true selects closed_loop. -->
   <arg name="enable_agc" default="false"/>
+  <arg name="gain_mode" default="off"/>
+  <arg name="fixed_gain_voltage" default="0.0"/>
+  <arg name="agc_target_min_v" default="2.5"/>
+  <arg name="agc_target_max_v" default="3.0"/>
+  <arg name="agc_step_v" default="0.01"/>
+  <arg name="adc_safety_limit_v" default="3.50"/>
 
   <node if="$(arg enable_adc)"
         pkg="robotic_fish_io"
@@ -21,11 +29,18 @@
     <rosparam command="load" file="$(arg config)"/>
   </node>
 
-  <node if="$(arg enable_agc)"
+  <node if="$(eval arg('enable_adc') and arg('enable_dac') and arg('enable_gain_control'))"
         pkg="robotic_fish_io"
         type="agc_node.py"
-        name="agc"
+        name="gain_control"
         output="screen">
     <rosparam command="load" file="$(arg config)"/>
+    <param name="agc/enabled" value="$(arg enable_agc)"/>
+    <param name="gain_control/mode" type="str" value="$(arg gain_mode)"/>
+    <param name="gain_control/fixed_voltage" value="$(arg fixed_gain_voltage)"/>
+    <param name="gain_control/target_min_v" value="$(arg agc_target_min_v)"/>
+    <param name="gain_control/target_max_v" value="$(arg agc_target_max_v)"/>
+    <param name="gain_control/step_v" value="$(arg agc_step_v)"/>
+    <param name="gain_control/adc_safety_limit_v" value="$(arg adc_safety_limit_v)"/>
   </node>
 </launch>

--- a/robots/robotic_fish_io/msg/AdcSample.msg
+++ b/robots/robotic_fish_io/msg/AdcSample.msg
@@ -7,5 +7,8 @@ float64 calibrated_voltage
 float64 calibration_gain
 bool calibration_applied
 string calibration_id
+# Last confirmed DAC gain-control voltage when this conversion started.
+float64 gain_control_voltage
+bool gain_control_voltage_valid
 time conversion_start
 time conversion_end

--- a/robots/robotic_fish_io/msg/GainControlState.msg
+++ b/robots/robotic_fish_io/msg/GainControlState.msg
@@ -1,0 +1,20 @@
+# Observable state for fixed/closed-loop LNA gain control and ADC protection.
+std_msgs/Header header
+string mode
+string state
+string reason
+float64 current_dac_voltage
+float64 commanded_dac_voltage
+float64 fixed_target_voltage
+float64 adc_max_raw_voltage
+float64 target_min_voltage
+float64 target_max_voltage
+float64 adc_safety_limit_voltage
+float64 adc_safety_recovery_voltage
+bool safety_active
+bool adc_valid
+bool dac_state_valid
+uint32 low_sample_count
+uint32 high_sample_count
+uint32 adjustment_count
+uint32 error_count

--- a/robots/robotic_fish_io/scripts/adc_node.py
+++ b/robots/robotic_fish_io/scripts/adc_node.py
@@ -2,11 +2,13 @@
 """Publish timestamped ADS1115 conversions with optional transfer calibration."""
 
 from pathlib import Path
+import math
 import time
 
 import rospkg
 import rospy
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
+from std_msgs.msg import Float32
 
 from robotic_fish_io.adc_calibration import AdcCalibration
 from robotic_fish_io import adc_driver
@@ -54,6 +56,9 @@ class AdcNode:
         samples_topic = rospy.get_param(
             "~adc/samples_topic", "/robotic_fish/adc/samples"
         )
+        gain_control_topic = rospy.get_param(
+            "~adc/gain_control_topic", "/robotic_fish/dac/state"
+        )
 
         self._validate_parameters()
         self.calibration = None
@@ -69,6 +74,15 @@ class AdcNode:
         self.diagnostic_pub = rospy.Publisher(
             "/diagnostics", DiagnosticArray, queue_size=10
         )
+        # Replacing this tuple is atomic in CPython, so sampling always observes
+        # a consistent validity/value pair from the subscriber callback.
+        self.gain_control_state = (False, 0.0)
+        self.gain_control_sub = rospy.Subscriber(
+            gain_control_topic,
+            Float32,
+            self._gain_control_callback,
+            queue_size=10,
+        )
         self.bus = None
         self.sample_sequence = 0
         self.error_count = 0
@@ -77,6 +91,15 @@ class AdcNode:
         self.last_sample_stamp = rospy.Time(0)
         self.last_conversion_ms = 0.0
         self.last_diagnostic_ns = 0
+
+    def _gain_control_callback(self, msg):
+        voltage = float(msg.data)
+        if not math.isfinite(voltage):
+            rospy.logwarn_throttle(
+                5.0, "Ignoring non-finite DAC gain-control voltage"
+            )
+            return
+        self.gain_control_state = (True, voltage)
 
     def _validate_parameters(self):
         adc_driver.validate_address(self.address)
@@ -189,6 +212,7 @@ class AdcNode:
     def _sample_channel(self, channel):
         anchor_ros = rospy.Time.now()
         anchor_ns = time.monotonic_ns()
+        gain_control_valid, gain_control_voltage = self.gain_control_state
         reading = adc_driver.read_timed_channel(
             self.bus,
             channel,
@@ -215,6 +239,8 @@ class AdcNode:
         msg.channel = reading.channel
         msg.raw = reading.raw
         msg.voltage = reading.voltage
+        msg.gain_control_voltage = gain_control_voltage
+        msg.gain_control_voltage_valid = gain_control_valid
         msg.conversion_start = start
         msg.conversion_end = end
         self.sample_sequence += 1
@@ -259,6 +285,12 @@ class AdcNode:
                 "" if self.calibration is None else self.calibration.calibration_id,
             ),
             KeyValue("calibration_status", self.calibration_status),
+            KeyValue(
+                "gain_control_voltage_v",
+                "unknown"
+                if not self.gain_control_state[0]
+                else "{:.2f}".format(self.gain_control_state[1]),
+            ),
         ]
         array = DiagnosticArray()
         array.header.stamp = rospy.Time.now()

--- a/robots/robotic_fish_io/scripts/agc_node.py
+++ b/robots/robotic_fish_io/scripts/agc_node.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Closed-loop AGC using raw ADC batches and the DAC voltage service."""
+"""Fixed/closed-loop LNA gain control with raw-ADC overrange protection."""
 
 import math
 import threading
@@ -8,63 +8,90 @@ import time
 import rospy
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 from std_msgs.msg import Float32
-from std_srvs.srv import SetBool, SetBoolResponse
+from std_srvs.srv import SetBool, SetBoolResponse, Trigger, TriggerResponse
 
-from robotic_fish_io.agc_controller import AgcController
 from robotic_fish_io import dac_driver
-from robotic_fish_io.msg import AdcSampleArray
+from robotic_fish_io.agc_controller import GainController
+from robotic_fish_io.msg import AdcSampleArray, GainControlState
 from robotic_fish_io.srv import SetDacVoltage
 
 
-class AgcNode:
+class GainControlNode:
     def __init__(self):
-        self.enabled = bool(rospy.get_param("~agc/enabled", True))
+        self.mode = self._configured_mode()
         self.start_voltage = float(
-            dac_driver.normalize_voltage(rospy.get_param("~agc/start_voltage", 0.0))
+            dac_driver.normalize_voltage(self._param("start_voltage", 0.0))
         )
         self.dac_channel = int(
-            rospy.get_param("~agc/dac_channel", dac_driver.DEFAULT_CHANNEL)
+            self._param("dac_channel", dac_driver.DEFAULT_CHANNEL)
         )
-        self.service_timeout = float(
-            rospy.get_param("~agc/service_timeout", 1.0)
-        )
+        self.service_timeout = float(self._param("service_timeout", 1.0))
+        self.adc_timeout = float(self._param("adc_timeout", 1.0))
         self.adc_topic = str(
-            rospy.get_param("~agc/adc_samples_topic", "/robotic_fish/adc/samples")
+            self._param("adc_samples_topic", "/robotic_fish/adc/samples")
         )
         self.dac_state_topic = str(
-            rospy.get_param("~agc/dac_state_topic", "/robotic_fish/dac/state")
+            self._param("dac_state_topic", "/robotic_fish/dac/state")
         )
         self.dac_service_name = str(
-            rospy.get_param(
-                "~agc/set_voltage_service", "/robotic_fish/dac/set_voltage"
-            )
+            self._param("set_voltage_service", "/robotic_fish/dac/set_voltage")
         )
         self.enable_service_name = str(
-            rospy.get_param("~agc/enable_service", "/robotic_fish/agc/enable")
+            self._param("enable_service", "/robotic_fish/agc/enable")
         )
-        self.controller = AgcController(
-            target_min_v=rospy.get_param("~agc/target_min_v", 2.5),
-            target_max_v=rospy.get_param("~agc/target_max_v", 3.0),
-            step_v=rospy.get_param("~agc/step_v", 0.01),
-            interval_s=rospy.get_param("~agc/interval_s", 0.5),
-            consecutive_samples=rospy.get_param("~agc/consecutive_samples", 3),
-            dac_min_v=rospy.get_param("~agc/dac_min_v", 0.0),
-            dac_max_v=rospy.get_param("~agc/dac_max_v", 5.0),
+        self.reset_service_name = str(
+            self._param(
+                "reset_safety_service", "/robotic_fish/gain_control/reset_safety"
+            )
+        )
+        self.state_topic = str(
+            self._param("state_topic", "/robotic_fish/gain_control/state")
+        )
+
+        self.controller = GainController(
+            mode=self.mode,
+            fixed_target_v=self._param("fixed_voltage", 0.0),
+            target_min_v=self._param("target_min_v", 2.5),
+            target_max_v=self._param("target_max_v", 3.0),
+            step_v=self._param("step_v", 0.01),
+            interval_s=self._param("interval_s", 0.5),
+            consecutive_samples=self._param("consecutive_samples", 3),
+            dac_min_v=self._param("dac_min_v", 0.0),
+            dac_max_v=self._param("dac_max_v", 5.0),
+            safety_limit_v=self._param("adc_safety_limit_v", 3.50),
+            safety_recovery_v=self._param("adc_safety_recovery_v", 3.30),
+            safety_step_v=self._param("safety_step_v", 0.10),
+            safety_interval_s=self._param("safety_interval_s", 0.10),
+            fixed_ramp_step_v=self._param("fixed_ramp_step_v", 0.05),
+            fixed_ramp_interval_s=self._param("fixed_ramp_interval_s", 0.10),
+            recovery_settle_s=self._param("recovery_settle_s", 0.20),
+            max_normal_step_v=self._param("max_normal_step_v", 0.10),
         )
         dac_driver.validate_channel(self.dac_channel)
-        if not math.isfinite(self.service_timeout) or self.service_timeout <= 0:
-            raise ValueError("AGC service_timeout must be positive")
+        if not math.isfinite(self.service_timeout) or self.service_timeout <= 0.0:
+            raise ValueError("gain-control service_timeout must be positive")
+        if not math.isfinite(self.adc_timeout) or self.adc_timeout <= 0.0:
+            raise ValueError("gain-control adc_timeout must be positive")
+        if not self.controller.dac_min_v <= self.start_voltage <= self.controller.dac_max_v:
+            raise ValueError("start_voltage is outside configured DAC limits")
 
         self.lock = threading.RLock()
         self.command_lock = threading.Lock()
         self.current_dac_voltage = None
+        self.commanded_dac_voltage = None
+        self.last_adc_monotonic_s = None
+        self.last_sample_stamp = rospy.Time(0)
         self.adjustments = 0
         self.error_count = 0
         self.last_error = ""
-        self.status = "waiting for DAC state"
-        self.last_sample_stamp = rospy.Time(0)
 
         self.dac_client = rospy.ServiceProxy(self.dac_service_name, SetDacVoltage)
+        self.state_pub = rospy.Publisher(
+            self.state_topic, GainControlState, queue_size=10, latch=True
+        )
+        self.diagnostic_pub = rospy.Publisher(
+            "/diagnostics", DiagnosticArray, queue_size=10
+        )
         self.adc_sub = rospy.Subscriber(
             self.adc_topic, AdcSampleArray, self._adc_callback, queue_size=10
         )
@@ -74,30 +101,37 @@ class AgcNode:
         self.enable_service = rospy.Service(
             self.enable_service_name, SetBool, self._enable_callback
         )
-        self.diagnostic_pub = rospy.Publisher(
-            "/diagnostics", DiagnosticArray, queue_size=10
+        self.reset_service = rospy.Service(
+            self.reset_service_name, Trigger, self._reset_safety_callback
         )
         self.diagnostic_timer = rospy.Timer(
             rospy.Duration(1.0), self._diagnostic_callback
         )
+        rospy.loginfo("Gain control started in '%s' mode", self.mode)
 
-    def _dac_state_callback(self, msg):
-        voltage = float(msg.data)
-        if not math.isfinite(voltage):
-            rospy.logwarn_throttle(5.0, "Ignoring non-finite DAC state")
-            return
-        with self.lock:
-            self.current_dac_voltage = voltage
-            if self.status == "waiting for DAC state":
-                self.status = "waiting for ADC samples"
+    @staticmethod
+    def _legacy_param(name, default):
+        return rospy.get_param("~agc/{}".format(name), default)
 
-    def _enable_callback(self, request):
-        with self.lock:
-            self.enabled = bool(request.data)
-            self.controller.reset_counts()
-            self.last_error = ""
-            self.status = "enabled" if self.enabled else "disabled"
-        return SetBoolResponse(True, "AGC {}".format(self.status))
+    @classmethod
+    def _param(cls, name, default):
+        full_name = "~gain_control/{}".format(name)
+        if rospy.has_param(full_name):
+            return rospy.get_param(full_name)
+        return cls._legacy_param(name, default)
+
+    @staticmethod
+    def _configured_mode():
+        mode_name = "~gain_control/mode"
+        legacy_name = "~agc/enabled"
+        mode_explicit = rospy.has_param(mode_name)
+        mode = str(rospy.get_param(mode_name, "off")).strip().lower()
+        legacy_enabled = bool(rospy.get_param(legacy_name, False))
+        if mode_explicit and legacy_enabled and mode not in ("off", "closed_loop"):
+            raise ValueError(
+                "gain_control/mode conflicts with deprecated agc/enabled=true"
+            )
+        return "closed_loop" if legacy_enabled else mode
 
     @staticmethod
     def _ordered_raw_voltages(msg):
@@ -108,8 +142,37 @@ class AgcNode:
                 raise ValueError("ADC batch contains a duplicate channel")
             by_channel[channel] = float(sample.voltage)
         if set(by_channel) != {0, 1, 2}:
-            raise ValueError("AGC requires one ADC0, ADC1, and ADC2 sample")
+            raise ValueError("gain control requires one ADC0, ADC1, and ADC2 sample")
         return [by_channel[channel] for channel in range(3)]
+
+    def _dac_state_callback(self, msg):
+        voltage = float(msg.data)
+        if not math.isfinite(voltage):
+            rospy.logwarn_throttle(5.0, "Ignoring non-finite DAC state")
+            return
+        if not self.controller.dac_min_v <= voltage <= self.controller.dac_max_v:
+            self._record_error("DAC state is outside configured limits")
+            return
+        with self.lock:
+            self.current_dac_voltage = voltage
+
+    def _enable_callback(self, request):
+        # Backward-compatible service: enabling selects closed-loop mode.
+        with self.lock:
+            self.controller.set_mode("closed_loop" if request.data else "off")
+            self.mode = self.controller.mode
+            self.last_error = ""
+        self._publish_state()
+        return SetBoolResponse(True, "gain mode is {}".format(self.mode))
+
+    def _reset_safety_callback(self, _request):
+        with self.lock:
+            if self.controller.safety_active:
+                return TriggerResponse(False, "ADC overrange protection is still active")
+            self.controller.reset_safety()
+            self.last_error = ""
+        self._publish_state()
+        return TriggerResponse(True, "gain-control safety latch reset")
 
     def _set_dac_voltage(self, target):
         try:
@@ -118,128 +181,197 @@ class AgcNode:
         except (rospy.ROSException, rospy.ServiceException) as exc:
             raise OSError("DAC service unavailable: {}".format(exc)) from exc
         if not response.success:
-            raise OSError("DAC rejected AGC command: {}".format(response.message))
-        return float(response.applied_voltage)
+            raise OSError("DAC rejected gain-control command: {}".format(response.message))
+        applied = float(response.applied_voltage)
+        if not math.isfinite(applied):
+            raise OSError("DAC returned a non-finite applied voltage")
+        if not self.controller.dac_min_v <= applied <= self.controller.dac_max_v:
+            raise OSError("DAC returned an applied voltage outside configured limits")
+        expected = float(dac_driver.normalize_voltage(target))
+        if abs(applied - expected) >= 0.005:
+            raise OSError(
+                "DAC applied {:.2f} V instead of requested {:.2f} V".format(
+                    applied, expected
+                )
+            )
+        return applied
 
-    def _record_error(self, message, disable=False):
+    def _record_error(self, message):
         with self.lock:
             self.controller.reset_counts()
             self.error_count += 1
             self.last_error = str(message)
-            self.status = "error"
-            if disable:
-                self.enabled = False
-        rospy.logerr_throttle(2.0, "AGC: %s", message)
+        rospy.logerr_throttle(2.0, "Gain control: %s", message)
 
     def _adc_callback(self, msg):
         try:
             raw_voltages = self._ordered_raw_voltages(msg)
         except ValueError as exc:
             self._record_error(exc)
+            self._publish_state()
             return
 
+        now = time.monotonic()
         with self.command_lock:
             with self.lock:
                 self.last_sample_stamp = msg.header.stamp
-                if not self.enabled:
-                    self.controller.reset_counts()
-                    self.status = "disabled"
-                    return
+                self.last_adc_monotonic_s = now
                 current = self.current_dac_voltage
+                mode = self.controller.mode
 
             if current is None:
+                maximum = max(raw_voltages)
+                # Off mode normally observes external DAC commands without taking
+                # ownership. An ADC overrange is the exception: command the known
+                # safe DAC minimum even when no prior DAC state was received.
+                if mode == "off" and maximum < self.controller.safety_limit_v:
+                    with self.lock:
+                        self.controller.current_max_raw_v = maximum
+                        self.controller.last_action = "waiting_for_dac_state"
+                    self._publish_state()
+                    return
                 try:
-                    applied = self._set_dac_voltage(self.start_voltage)
+                    initial_target = (
+                        self.controller.dac_min_v
+                        if maximum >= self.controller.safety_limit_v
+                        else self.start_voltage
+                    )
+                    applied = self._set_dac_voltage(initial_target)
                 except OSError as exc:
-                    self._record_error(exc, disable=True)
+                    self._record_error(exc)
+                    self._publish_state()
                     return
                 with self.lock:
                     self.current_dac_voltage = applied
-                    self.status = "initialized DAC"
-                rospy.loginfo("AGC initialized DAC to %.2f V", applied)
+                    self.commanded_dac_voltage = initial_target
+                    self.adjustments += 1
+                    self.controller.current_max_raw_v = maximum
+                    if maximum >= self.controller.safety_limit_v:
+                        self.controller.safety_active = True
+                        self.controller.last_action = "adc_overrange_at_dac_min"
+                    else:
+                        self.controller.last_action = "initialized_dac"
+                    self.last_error = ""
+                self._publish_state()
                 return
 
             try:
-                target = self.controller.observe(
-                    raw_voltages, current, time.monotonic()
-                )
+                target = self.controller.observe(raw_voltages, current, now)
             except ValueError as exc:
                 self._record_error(exc)
+                self._publish_state()
                 return
 
-            with self.lock:
-                self.status = self.controller.last_action
-                self.last_error = ""
-            if target is None:
-                return
+            if target is not None:
+                try:
+                    applied = self._set_dac_voltage(target)
+                except OSError as exc:
+                    self._record_error(exc)
+                    self._publish_state()
+                    return
+                with self.lock:
+                    self.current_dac_voltage = applied
+                    self.commanded_dac_voltage = target
+                    self.adjustments += 1
+                    self.last_error = ""
+                rospy.loginfo(
+                    "Gain control %s: DAC %.2f V, raw ADC max %.6f V",
+                    self.controller.last_action,
+                    applied,
+                    self.controller.current_max_raw_v,
+                )
+            else:
+                with self.lock:
+                    self.last_error = ""
+            self._publish_state()
 
-            try:
-                applied = self._set_dac_voltage(target)
-            except OSError as exc:
-                self._record_error(exc, disable=True)
-                return
-            with self.lock:
-                self.current_dac_voltage = applied
-                self.adjustments += 1
-                self.status = self.controller.last_action
-                self.last_error = ""
-            rospy.loginfo(
-                "AGC %s DAC to %.2f V (raw ADC max %.6f V)",
-                self.controller.last_action,
-                applied,
-                self.controller.current_max_raw_v,
-            )
+    def _adc_is_valid(self):
+        return (
+            self.last_adc_monotonic_s is not None
+            and time.monotonic() - self.last_adc_monotonic_s <= self.adc_timeout
+        )
+
+    def _state_message(self):
+        msg = GainControlState()
+        msg.header.stamp = rospy.Time.now()
+        msg.mode = self.controller.mode
+        msg.state = "adc_stale" if not self._adc_is_valid() else self.controller.last_action
+        msg.reason = self.last_error
+        msg.current_dac_voltage = (
+            float("nan") if self.current_dac_voltage is None else self.current_dac_voltage
+        )
+        msg.commanded_dac_voltage = (
+            float("nan")
+            if self.commanded_dac_voltage is None
+            else self.commanded_dac_voltage
+        )
+        msg.fixed_target_voltage = self.controller.fixed_target_v
+        msg.adc_max_raw_voltage = (
+            float("nan")
+            if self.controller.current_max_raw_v is None
+            else self.controller.current_max_raw_v
+        )
+        msg.target_min_voltage = self.controller.target_min_v
+        msg.target_max_voltage = self.controller.target_max_v
+        msg.adc_safety_limit_voltage = self.controller.safety_limit_v
+        msg.adc_safety_recovery_voltage = self.controller.safety_recovery_v
+        msg.safety_active = self.controller.safety_active
+        msg.adc_valid = self._adc_is_valid()
+        msg.dac_state_valid = self.current_dac_voltage is not None
+        msg.low_sample_count = self.controller.below_count
+        msg.high_sample_count = self.controller.above_count
+        msg.adjustment_count = self.adjustments
+        msg.error_count = self.error_count
+        return msg
+
+    def _publish_state(self):
+        with self.lock:
+            self.state_pub.publish(self._state_message())
 
     def _diagnostic_callback(self, _event):
         with self.lock:
+            msg = self._state_message()
             status = DiagnosticStatus()
-            status.name = "robotic_fish_io/agc"
+            status.name = "robotic_fish_io/gain_control"
             status.hardware_id = "adc-max-to-dac"
-            if self.last_error:
+            if self.last_error or msg.state == "adc_overrange_at_dac_min":
                 status.level = DiagnosticStatus.ERROR
-                status.message = self.last_error
-            elif not self.enabled:
-                status.level = DiagnosticStatus.OK
-                status.message = "AGC disabled"
-            elif self.current_dac_voltage is None:
+                status.message = self.last_error or msg.state
+            elif msg.safety_active or not msg.adc_valid or not msg.dac_state_valid:
                 status.level = DiagnosticStatus.WARN
-                status.message = "AGC waiting for DAC initialization"
+                status.message = msg.state
             else:
                 status.level = DiagnosticStatus.OK
-                status.message = self.status
+                status.message = msg.state
             status.values = [
-                KeyValue("enabled", str(self.enabled)),
-                KeyValue(
-                    "adc_max_raw_v",
-                    "unknown"
-                    if self.controller.current_max_raw_v is None
-                    else "{:.6f}".format(self.controller.current_max_raw_v),
-                ),
-                KeyValue(
-                    "dac_voltage_v",
-                    "unknown"
-                    if self.current_dac_voltage is None
-                    else "{:.2f}".format(self.current_dac_voltage),
-                ),
-                KeyValue("action", self.controller.last_action),
-                KeyValue("below_count", str(self.controller.below_count)),
-                KeyValue("above_count", str(self.controller.above_count)),
-                KeyValue("adjustments", str(self.adjustments)),
-                KeyValue("errors", str(self.error_count)),
+                KeyValue("mode", msg.mode),
+                KeyValue("state", msg.state),
+                KeyValue("adc_valid", str(msg.adc_valid)),
+                KeyValue("adc_max_raw_v", str(msg.adc_max_raw_voltage)),
+                KeyValue("dac_state_valid", str(msg.dac_state_valid)),
+                KeyValue("dac_voltage_v", str(msg.current_dac_voltage)),
+                KeyValue("safety_active", str(msg.safety_active)),
+                KeyValue("adjustments", str(msg.adjustment_count)),
+                KeyValue("errors", str(msg.error_count)),
             ]
             array = DiagnosticArray()
-            array.header.stamp = rospy.Time.now()
+            array.header.stamp = msg.header.stamp
             array.status = [status]
-        self.diagnostic_pub.publish(array)
+            self.diagnostic_pub.publish(array)
+            self.state_pub.publish(msg)
+
+
+# Preserve the old class name for code importing the ROS node directly.
+AgcNode = GainControlNode
 
 
 def main():
-    rospy.init_node("agc")
+    rospy.init_node("gain_control")
     try:
-        AgcNode()
+        GainControlNode()
         rospy.spin()
     except (ValueError, TypeError) as exc:
-        rospy.logfatal("Invalid AGC configuration: %s", exc)
+        rospy.logfatal("Invalid gain-control configuration: %s", exc)
         raise
 
 

--- a/robots/robotic_fish_io/src/robotic_fish_io/agc_controller.py
+++ b/robots/robotic_fish_io/src/robotic_fish_io/agc_controller.py
@@ -1,39 +1,89 @@
-"""Pure closed-loop AGC decision logic shared by the ROS node and tests."""
+"""Pure fixed/closed-loop gain-control decisions shared by ROS and tests."""
 
 import math
 
 from robotic_fish_io import dac_driver
 
 
-class AgcController:
-    """Adjust DAC voltage from the maximum of three uncalibrated ADC values."""
+class GainController:
+    """Control a DAC from the maximum of three uncalibrated ADC voltages."""
+
+    MODES = ("off", "fixed", "closed_loop")
 
     def __init__(
         self,
-        target_min_v,
-        target_max_v,
-        step_v,
-        interval_s,
-        consecutive_samples,
+        mode="off",
+        fixed_target_v=0.0,
+        target_min_v=2.5,
+        target_max_v=3.0,
+        step_v=0.01,
+        interval_s=0.5,
+        consecutive_samples=3,
         dac_min_v=0.0,
         dac_max_v=5.0,
+        safety_limit_v=3.50,
+        safety_recovery_v=3.30,
+        safety_step_v=0.10,
+        safety_interval_s=0.10,
+        fixed_ramp_step_v=0.05,
+        fixed_ramp_interval_s=0.10,
+        recovery_settle_s=0.20,
+        max_normal_step_v=0.10,
     ):
+        self.mode = str(mode).strip().lower()
+        if self.mode not in self.MODES:
+            raise ValueError("gain mode must be one of {}".format(", ".join(self.MODES)))
+
+        self.dac_min_v = self._dac_voltage(dac_min_v, "dac_min_v")
+        self.dac_max_v = self._dac_voltage(dac_max_v, "dac_max_v")
+        if not self.dac_min_v < self.dac_max_v:
+            raise ValueError("DAC minimum must be below maximum")
+
+        self.fixed_target_v = self._bounded_dac(fixed_target_v, "fixed_target_v")
         self.target_min_v = self._finite(target_min_v, "target_min_v")
         self.target_max_v = self._finite(target_max_v, "target_max_v")
-        self.step_v = float(dac_driver.normalize_voltage(step_v))
-        self.interval_s = self._finite(interval_s, "interval_s")
-        self.dac_min_v = float(dac_driver.normalize_voltage(dac_min_v))
-        self.dac_max_v = float(dac_driver.normalize_voltage(dac_max_v))
         if not 0.0 <= self.target_min_v < self.target_max_v <= 4.096:
+            raise ValueError("ADC target range must satisfy 0 <= min < max <= 4.096 V")
+
+        self.max_normal_step_v = self._positive_dac_step(
+            max_normal_step_v, "max_normal_step_v"
+        )
+        self.step_v = self._positive_dac_step(step_v, "step_v")
+        self.fixed_ramp_step_v = self._positive_dac_step(
+            fixed_ramp_step_v, "fixed_ramp_step_v"
+        )
+        if self.step_v > self.max_normal_step_v:
+            raise ValueError("AGC step_v exceeds max_normal_step_v")
+        if self.fixed_ramp_step_v > self.max_normal_step_v:
+            raise ValueError("fixed_ramp_step_v exceeds max_normal_step_v")
+
+        self.safety_step_v = self._positive_dac_step(
+            safety_step_v, "safety_step_v"
+        )
+        self.interval_s = self._interval(interval_s, "interval_s")
+        self.fixed_ramp_interval_s = self._interval(
+            fixed_ramp_interval_s, "fixed_ramp_interval_s"
+        )
+        self.safety_interval_s = self._interval(
+            safety_interval_s, "safety_interval_s"
+        )
+        self.recovery_settle_s = self._finite(
+            recovery_settle_s, "recovery_settle_s"
+        )
+        if self.recovery_settle_s < 0.0:
+            raise ValueError("recovery_settle_s must not be negative")
+
+        self.safety_limit_v = self._finite(safety_limit_v, "safety_limit_v")
+        self.safety_recovery_v = self._finite(
+            safety_recovery_v, "safety_recovery_v"
+        )
+        if not 0.0 <= self.safety_recovery_v < self.safety_limit_v <= 4.096:
             raise ValueError(
-                "ADC target range must satisfy 0 <= min < max <= 4.096 V"
+                "ADC safety thresholds must satisfy 0 <= recovery < limit <= 4.096 V"
             )
-        if self.step_v <= 0.0:
-            raise ValueError("AGC step_v must be positive")
-        if not 0.02 <= self.interval_s <= 3600.0:
-            raise ValueError("AGC interval_s must be between 0.02 and 3600 s")
-        if not self.dac_min_v < self.dac_max_v:
-            raise ValueError("AGC DAC minimum must be below maximum")
+        if self.target_max_v >= self.safety_limit_v:
+            raise ValueError("ADC target maximum must be below the safety limit")
+
         if isinstance(consecutive_samples, bool):
             raise ValueError("consecutive_samples must be an integer")
         try:
@@ -46,9 +96,13 @@ class AgcController:
 
         self.below_count = 0
         self.above_count = 0
-        self.last_adjustment_s = 0.0
+        self.last_adjustment_s = float("-inf")
+        self.last_safety_adjustment_s = float("-inf")
         self.current_max_raw_v = None
         self.last_action = "waiting"
+        self.safety_active = False
+        self.fixed_limited = False
+        self.settle_until_s = float("-inf")
 
     @staticmethod
     def _finite(value, name):
@@ -62,15 +116,97 @@ class AgcController:
             raise ValueError("{} must be finite".format(name))
         return value
 
+    @classmethod
+    def _dac_voltage(cls, value, name):
+        try:
+            return float(dac_driver.normalize_voltage(cls._finite(value, name)))
+        except ValueError as exc:
+            raise ValueError("{} must be within the DAC hardware range".format(name)) from exc
+
+    @classmethod
+    def _positive_dac_step(cls, value, name):
+        normalized = cls._dac_voltage(value, name)
+        if normalized <= 0.0:
+            raise ValueError("{} must be positive".format(name))
+        return normalized
+
+    @classmethod
+    def _interval(cls, value, name):
+        interval = cls._finite(value, name)
+        if not 0.02 <= interval <= 3600.0:
+            raise ValueError("{} must be between 0.02 and 3600 s".format(name))
+        return interval
+
+    def _bounded_dac(self, value, name):
+        voltage = self._dac_voltage(value, name)
+        if not self.dac_min_v <= voltage <= self.dac_max_v:
+            raise ValueError("{} is outside configured DAC limits".format(name))
+        return voltage
+
     def reset_counts(self):
         self.below_count = 0
         self.above_count = 0
+
+    def reset_safety(self):
+        """Clear the fixed-mode safety latch; an active overrange remains active."""
+        self.fixed_limited = False
+        self.reset_counts()
+        self.last_action = "safety_active" if self.safety_active else "reset"
+
+    def set_mode(self, mode):
+        mode = str(mode).strip().lower()
+        if mode not in self.MODES:
+            raise ValueError("gain mode must be one of {}".format(", ".join(self.MODES)))
+        self.mode = mode
+        self.reset_counts()
+        self.last_action = mode
+
+    def _target(self, requested):
+        bounded = min(self.dac_max_v, max(self.dac_min_v, requested))
+        return float(dac_driver.normalize_voltage(bounded))
+
+    def _safety_decision(self, maximum, current, now):
+        if maximum >= self.safety_limit_v:
+            if not self.safety_active:
+                self.last_safety_adjustment_s = float("-inf")
+            self.safety_active = True
+            self.reset_counts()
+
+        if not self.safety_active:
+            return False, None
+
+        if maximum <= self.safety_recovery_v:
+            self.safety_active = False
+            self.reset_counts()
+            if self.mode == "fixed":
+                self.fixed_limited = True
+                self.last_action = "fixed_limited"
+            elif self.mode == "closed_loop":
+                self.settle_until_s = now + self.recovery_settle_s
+                self.last_action = "settling"
+            else:
+                self.last_action = "off"
+            return True, None
+
+        if current <= self.dac_min_v:
+            self.last_action = "adc_overrange_at_dac_min"
+            return True, None
+        if now - self.last_safety_adjustment_s < self.safety_interval_s:
+            self.last_action = "safety_waiting"
+            return True, None
+
+        target = self._target(current - self.safety_step_v)
+        self.last_safety_adjustment_s = now
+        self.last_action = "safety_decreasing"
+        if self.mode == "fixed":
+            self.fixed_limited = True
+        return True, target
 
     def observe(self, raw_voltages, current_dac_v, now_s):
         """Return the next DAC voltage, or ``None`` when no change is due."""
         if not isinstance(raw_voltages, (list, tuple)) or len(raw_voltages) != 3:
             self.reset_counts()
-            raise ValueError("AGC requires ADC0, ADC1, and ADC2")
+            raise ValueError("gain control requires ADC0, ADC1, and ADC2")
         values = [
             self._finite(value, "ADC{} voltage".format(channel))
             for channel, value in enumerate(raw_voltages)
@@ -79,10 +215,43 @@ class AgcController:
         now = self._finite(now_s, "monotonic time")
         if not self.dac_min_v <= current <= self.dac_max_v:
             self.reset_counts()
-            raise ValueError("Current DAC voltage is outside the AGC limits")
+            raise ValueError("Current DAC voltage is outside configured limits")
 
         maximum = max(values)
         self.current_max_raw_v = maximum
+        handled, target = self._safety_decision(maximum, current, now)
+        if handled:
+            return target
+
+        if self.mode == "off":
+            self.reset_counts()
+            self.last_action = "off"
+            return None
+
+        if self.mode == "fixed":
+            self.reset_counts()
+            if self.fixed_limited:
+                self.last_action = "fixed_limited"
+                return None
+            difference = self.fixed_target_v - current
+            if abs(difference) < 0.005:
+                self.last_action = "fixed_holding"
+                return None
+            if now - self.last_adjustment_s < self.fixed_ramp_interval_s:
+                self.last_action = "fixed_waiting"
+                return None
+            direction = 1.0 if difference > 0.0 else -1.0
+            target = self._target(
+                current + direction * min(abs(difference), self.fixed_ramp_step_v)
+            )
+            self.last_adjustment_s = now
+            self.last_action = "fixed_ramping_up" if direction > 0 else "fixed_ramping_down"
+            return target
+
+        if now < self.settle_until_s:
+            self.reset_counts()
+            self.last_action = "settling"
+            return None
         if maximum < self.target_min_v:
             self.below_count += 1
             self.above_count = 0
@@ -104,14 +273,36 @@ class AgcController:
         if now - self.last_adjustment_s < self.interval_s:
             return None
 
-        requested = current + direction * self.step_v
-        bounded = min(self.dac_max_v, max(self.dac_min_v, requested))
-        target = float(dac_driver.normalize_voltage(bounded))
+        target = self._target(current + direction * self.step_v)
         self.reset_counts()
         if target == current:
             self.last_action = "dac_max" if direction > 0 else "dac_min"
             return None
-
-        self.last_action = "increase" if direction > 0 else "decrease"
         self.last_adjustment_s = now
+        self.last_action = "increase" if direction > 0 else "decrease"
         return target
+
+
+class AgcController(GainController):
+    """Backward-compatible closed-loop-only controller interface."""
+
+    def __init__(
+        self,
+        target_min_v,
+        target_max_v,
+        step_v,
+        interval_s,
+        consecutive_samples,
+        dac_min_v=0.0,
+        dac_max_v=5.0,
+    ):
+        super().__init__(
+            mode="closed_loop",
+            target_min_v=target_min_v,
+            target_max_v=target_max_v,
+            step_v=step_v,
+            interval_s=interval_s,
+            consecutive_samples=consecutive_samples,
+            dac_min_v=dac_min_v,
+            dac_max_v=dac_max_v,
+        )

--- a/robots/robotic_fish_io/test/test_agc.py
+++ b/robots/robotic_fish_io/test/test_agc.py
@@ -9,7 +9,7 @@ import unittest
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PACKAGE_ROOT / "src"))
 
-from robotic_fish_io.agc_controller import AgcController  # noqa: E402
+from robotic_fish_io.agc_controller import AgcController, GainController  # noqa: E402
 
 
 def make_controller(**overrides):
@@ -99,6 +99,98 @@ class AgcControllerTests(unittest.TestCase):
         for overrides in invalid:
             with self.subTest(overrides=overrides), self.assertRaises(ValueError):
                 make_controller(**overrides)
+
+
+class GainControllerTests(unittest.TestCase):
+    def make_gain_controller(self, **overrides):
+        parameters = {
+            "mode": "fixed",
+            "fixed_target_v": 1.0,
+            "target_min_v": 2.5,
+            "target_max_v": 3.0,
+            "step_v": 0.01,
+            "interval_s": 0.5,
+            "consecutive_samples": 3,
+            "dac_min_v": 0.0,
+            "dac_max_v": 5.0,
+            "safety_limit_v": 3.5,
+            "safety_recovery_v": 3.3,
+            "safety_step_v": 0.1,
+            "safety_interval_s": 0.1,
+            "fixed_ramp_step_v": 0.05,
+            "fixed_ramp_interval_s": 0.1,
+            "recovery_settle_s": 0.2,
+            "max_normal_step_v": 0.1,
+        }
+        parameters.update(overrides)
+        return GainController(**parameters)
+
+    def test_fixed_mode_ramps_and_holds(self):
+        controller = self.make_gain_controller()
+        safe = [1.0, 1.1, 1.2]
+        self.assertEqual(controller.observe(safe, 0.0, 1.0), 0.05)
+        self.assertIsNone(controller.observe(safe, 0.05, 1.05))
+        self.assertEqual(controller.last_action, "fixed_waiting")
+        self.assertEqual(controller.observe(safe, 0.05, 1.1), 0.10)
+        self.assertIsNone(controller.observe(safe, 1.0, 2.0))
+        self.assertEqual(controller.last_action, "fixed_holding")
+
+    def test_exact_safety_limit_immediately_overrides_normal_interval(self):
+        controller = self.make_gain_controller(mode="closed_loop", consecutive_samples=1)
+        controller.observe([1.0, 1.1, 1.2], 1.0, 1.0)
+        self.assertEqual(controller.observe([3.5, 3.0, 3.0], 1.01, 1.01), 0.91)
+        self.assertTrue(controller.safety_active)
+        self.assertEqual(controller.last_action, "safety_decreasing")
+
+    def test_safety_decreases_until_recovery_then_latches_fixed_mode(self):
+        controller = self.make_gain_controller()
+        high = [3.6, 3.2, 3.1]
+        self.assertEqual(controller.observe(high, 1.0, 1.0), 0.9)
+        self.assertIsNone(controller.observe(high, 0.9, 1.05))
+        self.assertEqual(controller.observe(high, 0.9, 1.1), 0.8)
+        self.assertIsNone(controller.observe([3.3, 3.0, 2.9], 0.8, 1.2))
+        self.assertFalse(controller.safety_active)
+        self.assertTrue(controller.fixed_limited)
+        self.assertEqual(controller.last_action, "fixed_limited")
+        self.assertIsNone(controller.observe([1.0, 1.1, 1.2], 0.8, 2.0))
+        controller.reset_safety()
+        self.assertEqual(controller.observe([1.0, 1.1, 1.2], 0.8, 2.1), 0.85)
+
+    def test_closed_loop_settles_after_safety_recovery(self):
+        controller = self.make_gain_controller(
+            mode="closed_loop", consecutive_samples=1, recovery_settle_s=0.2
+        )
+        self.assertEqual(controller.observe([3.6, 3.0, 3.0], 1.0, 1.0), 0.9)
+        self.assertIsNone(controller.observe([3.3, 3.0, 3.0], 0.9, 1.1))
+        self.assertEqual(controller.last_action, "settling")
+        self.assertIsNone(controller.observe([1.0, 1.1, 1.2], 0.9, 1.2))
+        self.assertEqual(controller.observe([1.0, 1.1, 1.2], 0.9, 1.3), 0.91)
+
+    def test_off_mode_only_acts_for_safety(self):
+        controller = self.make_gain_controller(mode="off")
+        self.assertIsNone(controller.observe([1.0, 1.1, 1.2], 1.0, 1.0))
+        self.assertEqual(controller.last_action, "off")
+        self.assertEqual(controller.observe([3.5, 3.0, 3.0], 1.0, 1.1), 0.9)
+
+    def test_overrange_at_dac_min_is_latched_as_error_state(self):
+        controller = self.make_gain_controller(mode="closed_loop")
+        self.assertIsNone(controller.observe([3.6, 3.0, 3.0], 0.0, 1.0))
+        self.assertTrue(controller.safety_active)
+        self.assertEqual(controller.last_action, "adc_overrange_at_dac_min")
+
+    def test_gain_configuration_rejects_unsafe_values(self):
+        invalid = [
+            {"mode": "automatic"},
+            {"fixed_target_v": 5.01},
+            {"step_v": 0.11},
+            {"fixed_ramp_step_v": 0.11},
+            {"safety_limit_v": 3.3, "safety_recovery_v": 3.3},
+            {"safety_limit_v": 4.097},
+            {"target_max_v": 3.5},
+        ]
+        for overrides in invalid:
+            with self.subTest(overrides=overrides), self.assertRaises(ValueError):
+                self.make_gain_controller(**overrides)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What is this

This PR adds the ROS 1 hardware interface and control pipeline for the robotic
fish acoustic module.

It provides timestamped three-channel ADC acquisition, independent ADC
calibration, serial DAC control, fixed and closed-loop LNA gain control, ADC
overrange protection, sonic teleoperation, and complete rosbag recording.

### Details

#### ADC acquisition and calibration

- Add timestamped ADS1115 acquisition for ADC0, ADC1, and ADC2.
- Record the conversion start, conversion end, and midpoint timestamp for each
  channel independently.
- Publish both individual ADC samples and complete three-channel sample groups.
- Apply an independent piecewise-linear calibration curve to each channel.
- Use the validated `calbri05` calibration data by default.
- Fall back the complete three-channel group to raw voltages when any channel
  is outside the calibration range.
- Record the latest confirmed DAC gain-control voltage at the start of each ADC
  conversion.

#### DAC and LNA gain control

- Add safe serial DAC control with command validation and echo verification.
- Limit DAC output to the supported 0.00–5.00 V range.
- Apply 0 V on normal shutdown by default.
- Add `off`, `fixed`, and `closed_loop` gain-control modes.
- Ramp gradually toward a fixed DAC target instead of applying an immediate
  voltage jump.
- Adjust the DAC from the maximum raw voltage of the three ADC channels in
  closed-loop mode.
- Reject invalid parameters, non-finite values, stale ADC data, and invalid DAC
  state.

#### ADC safety protection

- Trigger software protection when any raw ADC channel reaches 3.50 V.
- Bypass normal AGC timing and reduce the DAC by 0.10 V every 0.10 seconds.
- Continue reducing the DAC until the maximum raw ADC voltage is at or below
  the 3.30 V recovery threshold.
- Latch fixed mode in `fixed_limited` after an overrange event.
- Report `adc_overrange_at_dac_min` if the ADC remains unsafe with the DAC
  already at 0 V.
- Publish the complete control and safety state through
  `/robotic_fish/gain_control/state`.

#### Launch and system integration

- Add package-only sensor IO startup through `sensor_io.launch`.
- Add combined spinal and sensor IO startup through `io.launch`.
- Expose fixed voltage, closed-loop target range, adjustment step, and ADC
  safety threshold as roslaunch arguments.
- Keep the previous `enable_agc` interface as a compatibility option.
- Add `sonic_teleop` for joystick-based manual and automatic tail control.

#### Data recording

- Record ADC samples, confirmed DAC state, gain-control state, diagnostics,
  joystick input, IMU data, servo targets, and servo feedback.
- Include calibration information and the DAC voltage associated with each ADC
  conversion.
- Add an English README covering configuration, startup, safety behavior,
  rosbag usage, hardware setup, and troubleshooting.

#### Key commits

- `6b017d82`: Add timestamped ADC and DAC ROS interfaces.
- `76bac0ea`: Add ADC calibration support.
- `51e59f53`: Add the initial AGC implementation.
- `e2f4a6fc`: Add sonic joystick teleoperation.
- `c8bfa846`: Add rosbag recording and the updated ADC calibration.
- `408a249a`: Separate and adjust the robotic-fish IO launch logic.
- `c1f7be33`: Record LNA control voltage in ADC samples.
- `3a8f40cd`: Add safe fixed and closed-loop LNA gain-control modes.
- `d52c78c5`: Record gain-control state and update the IO documentation.

### Validation

- Built `robotic_fish_io`, `robotic_fish`, and `spinal` successfully.
- Passed all 29 `robotic_fish_io` unit tests.
- Verified fixed-voltage ramping with a simulated DAC service.
- Verified the 3.50 V safety trigger, gradual DAC reduction, and minimum-DAC
  lockout.
- Verified manual, automatic, and stop behavior in `sonic_teleop` with simulated
  joystick input.
- Verified rosbag recording and playback for all 9 configured topics.
- Recorded 180 test messages across the complete topic set without migration or
  bag-index errors.